### PR TITLE
feat: add typed Rust MVP runtime skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "harness-commands",
+ "harness-core",
  "harness-runtime",
  "harness-session",
  "harness-tools",

--- a/crates/harness-cli/Cargo.toml
+++ b/crates/harness-cli/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 clap.workspace = true
+harness-core = { path = "../harness-core" }
 harness-commands = { path = "../harness-commands" }
 harness-runtime = { path = "../harness-runtime" }
 harness-session = { path = "../harness-session" }

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use harness_core::Prompt;
 use harness_runtime::RuntimeEngine;
 
 #[derive(Debug, Parser)]
@@ -28,28 +29,40 @@ fn main() {
             println!("{}", engine.summary());
         }
         CliCommand::Route { prompt } => {
-            let matches = engine.route(&prompt);
-            println!("{}", serde_json::to_string_pretty(&matches).unwrap());
+            let matches = engine.route(&Prompt::new(prompt));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&matches).expect("serialize route result")
+            );
         }
         CliCommand::Bootstrap { prompt } => {
-            let report = engine.bootstrap(&prompt).unwrap();
-            println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            let report = engine
+                .bootstrap(Prompt::new(prompt))
+                .expect("bootstrap runtime turn");
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report).expect("serialize bootstrap report")
+            );
         }
         CliCommand::Tools => {
             println!(
                 "{}",
-                serde_json::to_string_pretty(engine.tools.list()).unwrap()
+                serde_json::to_string_pretty(engine.tools.list()).expect("serialize tool list")
             );
         }
         CliCommand::Commands => {
             println!(
                 "{}",
-                serde_json::to_string_pretty(engine.commands.list()).unwrap()
+                serde_json::to_string_pretty(engine.commands.list())
+                    .expect("serialize command list")
             );
         }
         CliCommand::SessionShow { id } => {
-            let session = engine.load_session(&id).unwrap();
-            println!("{}", serde_json::to_string_pretty(&session).unwrap());
+            let session = engine.load_session(&id).expect("load session by id");
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&session).expect("serialize session")
+            );
         }
     }
 }

--- a/crates/harness-commands/src/lib.rs
+++ b/crates/harness-commands/src/lib.rs
@@ -1,14 +1,15 @@
+use harness_core::CommandName;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandDefinition {
-    pub name: String,
+    pub name: CommandName,
     pub description: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandResult {
-    pub name: String,
+    pub name: CommandName,
     pub handled: bool,
     pub message: String,
 }
@@ -23,15 +24,15 @@ impl CommandRegistry {
         Self {
             commands: vec![
                 CommandDefinition {
-                    name: "review".into(),
+                    name: CommandName::new("review"),
                     description: "Review code or diffs".into(),
                 },
                 CommandDefinition {
-                    name: "agents".into(),
+                    name: CommandName::new("agents"),
                     description: "Inspect agent state".into(),
                 },
                 CommandDefinition {
-                    name: "setup".into(),
+                    name: CommandName::new("setup"),
                     description: "Show runtime setup state".into(),
                 },
             ],
@@ -42,23 +43,11 @@ impl CommandRegistry {
         &self.commands
     }
 
-    pub fn find(&self, query: &str) -> Vec<CommandDefinition> {
-        let needle = query.to_ascii_lowercase();
-        self.commands
-            .iter()
-            .filter(|command| {
-                command.name.to_ascii_lowercase().contains(&needle)
-                    || command.description.to_ascii_lowercase().contains(&needle)
-            })
-            .cloned()
-            .collect()
-    }
-
-    pub fn execute(&self, name: &str, prompt: &str) -> CommandResult {
+    pub fn execute(&self, name: &CommandName, prompt: &str) -> CommandResult {
         match self
             .commands
             .iter()
-            .find(|command| command.name.eq_ignore_ascii_case(name))
+            .find(|command| command.name.0.eq_ignore_ascii_case(&name.0))
         {
             Some(command) => CommandResult {
                 name: command.name.clone(),
@@ -69,7 +58,7 @@ impl CommandRegistry {
                 ),
             },
             None => CommandResult {
-                name: name.to_string(),
+                name: name.clone(),
                 handled: false,
                 message: format!("unknown command: {}", name),
             },

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -16,6 +17,61 @@ impl Default for SessionId {
         Self::new()
     }
 }
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub struct TurnIndex(pub usize);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct Prompt(pub String);
+
+impl Prompt {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ToolName(pub String);
+
+impl ToolName {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CommandName(pub String);
+
+impl CommandName {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for CommandName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub struct MatchScore(pub usize);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct UsageSummary {
@@ -40,18 +96,47 @@ pub struct PermissionDenial {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RuntimeEvent {
-    SessionStarted { session_id: SessionId },
-    PromptReceived { prompt: String },
-    RouteComputed { match_count: usize },
-    CommandMatched { name: String, score: usize },
-    ToolMatched { name: String, score: usize },
-    PermissionDenied { subject: String, reason: String },
-    CommandInvoked { name: String },
-    CommandCompleted { name: String, handled: bool },
-    ToolInvoked { name: String },
-    ToolCompleted { name: String, handled: bool },
-    TurnCompleted { stop_reason: String },
-    SessionPersisted { path: String },
+    SessionStarted {
+        session_id: SessionId,
+    },
+    PromptReceived {
+        prompt: Prompt,
+    },
+    RouteComputed {
+        match_count: usize,
+    },
+    CommandMatched {
+        name: CommandName,
+        score: MatchScore,
+    },
+    ToolMatched {
+        name: ToolName,
+        score: MatchScore,
+    },
+    PermissionDenied {
+        subject: String,
+        reason: String,
+    },
+    CommandInvoked {
+        name: CommandName,
+    },
+    CommandCompleted {
+        name: CommandName,
+        handled: bool,
+    },
+    ToolInvoked {
+        name: ToolName,
+    },
+    ToolCompleted {
+        name: ToolName,
+        handled: bool,
+    },
+    TurnCompleted {
+        stop_reason: String,
+    },
+    SessionPersisted {
+        path: String,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -1,14 +1,23 @@
 use harness_commands::{CommandRegistry, CommandResult};
-use harness_core::{PermissionDenial, RuntimeEvent};
+use harness_core::{
+    CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName,
+};
 use harness_session::{SessionState, SessionStore, TranscriptStore};
 use harness_tools::{PermissionPolicy, ToolRegistry, ToolResult};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchKind {
+    Command,
+    Tool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RoutedMatch {
-    pub kind: String,
+    pub kind: MatchKind,
     pub name: String,
-    pub score: usize,
+    pub score: MatchScore,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -45,14 +54,16 @@ impl Default for RuntimeEngine {
 impl RuntimeEngine {
     pub fn summary(&self) -> String {
         format!(
-            "commands={} tools={} denied_prefixes=bash",
+            "commands={} tools={} denied_prefixes={}",
             self.commands.list().len(),
-            self.tools.list().len()
+            self.tools.list().len(),
+            self.permissions.denied_prefixes().join(",")
         )
     }
 
-    pub fn route(&self, prompt: &str) -> Vec<RoutedMatch> {
+    pub fn route(&self, prompt: &Prompt) -> Vec<RoutedMatch> {
         let tokens: Vec<String> = prompt
+            .as_str()
             .split(|c: char| c.is_whitespace() || c == '/' || c == '-')
             .filter(|token| !token.is_empty())
             .map(|token| token.to_ascii_lowercase())
@@ -62,7 +73,7 @@ impl RuntimeEngine {
 
         for command in self.commands.list() {
             let haystacks = [
-                command.name.to_ascii_lowercase(),
+                command.name.0.to_ascii_lowercase(),
                 command.description.to_ascii_lowercase(),
             ];
             let score = tokens
@@ -71,16 +82,16 @@ impl RuntimeEngine {
                 .count();
             if score > 0 {
                 matches.push(RoutedMatch {
-                    kind: "command".into(),
-                    name: command.name.clone(),
-                    score,
+                    kind: MatchKind::Command,
+                    name: command.name.to_string(),
+                    score: MatchScore(score),
                 });
             }
         }
 
         for tool in self.tools.list() {
             let haystacks = [
-                tool.name.to_ascii_lowercase(),
+                tool.name.0.to_ascii_lowercase(),
                 tool.description.to_ascii_lowercase(),
             ];
             let score = tokens
@@ -89,9 +100,9 @@ impl RuntimeEngine {
                 .count();
             if score > 0 {
                 matches.push(RoutedMatch {
-                    kind: "tool".into(),
-                    name: tool.name.clone(),
-                    score,
+                    kind: MatchKind::Tool,
+                    name: tool.name.to_string(),
+                    score: MatchScore(score),
                 });
             }
         }
@@ -99,45 +110,47 @@ impl RuntimeEngine {
         matches.sort_by(|a, b| {
             b.score
                 .cmp(&a.score)
-                .then_with(|| a.kind.cmp(&b.kind))
+                .then_with(|| format!("{:?}", a.kind).cmp(&format!("{:?}", b.kind)))
                 .then_with(|| a.name.cmp(&b.name))
         });
         matches
     }
 
-    pub fn bootstrap(&self, prompt: &str) -> Result<TurnReport, String> {
+    pub fn bootstrap(&self, prompt: Prompt) -> Result<TurnReport, String> {
         let mut session = SessionState::default();
         let mut transcript = TranscriptStore::default();
         let mut events = vec![RuntimeEvent::SessionStarted {
-            session_id: session.session_id.clone(),
+            session_id: SessionId(session.session_id.0),
         }];
         events.push(RuntimeEvent::PromptReceived {
-            prompt: prompt.to_string(),
+            prompt: prompt.clone(),
         });
 
-        let matches = self.route(prompt);
+        let matches = self.route(&prompt);
         events.push(RuntimeEvent::RouteComputed {
             match_count: matches.len(),
         });
 
         for matched in &matches {
-            match matched.kind.as_str() {
-                "command" => events.push(RuntimeEvent::CommandMatched {
-                    name: matched.name.clone(),
+            match matched.kind {
+                MatchKind::Command => events.push(RuntimeEvent::CommandMatched {
+                    name: CommandName::new(matched.name.clone()),
                     score: matched.score,
                 }),
-                "tool" => events.push(RuntimeEvent::ToolMatched {
-                    name: matched.name.clone(),
+                MatchKind::Tool => events.push(RuntimeEvent::ToolMatched {
+                    name: ToolName::new(matched.name.clone()),
                     score: matched.score,
                 }),
-                _ => {}
             }
         }
 
         let denials: Vec<PermissionDenial> = matches
             .iter()
-            .filter(|matched| matched.kind == "tool")
-            .filter_map(|matched| self.permissions.denial_for(&matched.name))
+            .filter(|matched| matched.kind == MatchKind::Tool)
+            .filter_map(|matched| {
+                self.permissions
+                    .denial_for(&ToolName::new(matched.name.clone()))
+            })
             .collect();
 
         for denial in &denials {
@@ -149,14 +162,13 @@ impl RuntimeEngine {
 
         let command_results: Vec<CommandResult> = matches
             .iter()
-            .filter(|matched| matched.kind == "command")
+            .filter(|matched| matched.kind == MatchKind::Command)
             .map(|matched| {
-                events.push(RuntimeEvent::CommandInvoked {
-                    name: matched.name.clone(),
-                });
-                let result = self.commands.execute(&matched.name, prompt);
+                let name = CommandName::new(matched.name.clone());
+                events.push(RuntimeEvent::CommandInvoked { name: name.clone() });
+                let result = self.commands.execute(&name, prompt.as_str());
                 events.push(RuntimeEvent::CommandCompleted {
-                    name: matched.name.clone(),
+                    name,
                     handled: result.handled,
                 });
                 result
@@ -165,23 +177,26 @@ impl RuntimeEngine {
 
         let tool_results: Vec<ToolResult> = matches
             .iter()
-            .filter(|matched| matched.kind == "tool")
-            .filter(|matched| self.permissions.denial_for(&matched.name).is_none())
+            .filter(|matched| matched.kind == MatchKind::Tool)
+            .filter(|matched| {
+                self.permissions
+                    .denial_for(&ToolName::new(matched.name.clone()))
+                    .is_none()
+            })
             .map(|matched| {
-                events.push(RuntimeEvent::ToolInvoked {
-                    name: matched.name.clone(),
-                });
-                let result = self.tools.execute(&matched.name, prompt);
+                let name = ToolName::new(matched.name.clone());
+                events.push(RuntimeEvent::ToolInvoked { name: name.clone() });
+                let result = self.tools.execute(&name, prompt.as_str());
                 events.push(RuntimeEvent::ToolCompleted {
-                    name: matched.name.clone(),
+                    name,
                     handled: result.handled,
                 });
                 result
             })
             .collect();
 
-        session.messages.push(prompt.to_string());
-        session.usage = session.usage.add_turn(prompt, "turn completed");
+        session.messages.push(prompt.clone());
+        session.usage = session.usage.add_turn(prompt.as_str(), "turn completed");
         transcript.append(prompt);
         transcript.flush();
 

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -1,12 +1,13 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use harness_core::{RuntimeError, SessionId, UsageSummary};
+use harness_core::{Prompt, RuntimeError, SessionId, TurnIndex, UsageSummary};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TranscriptEntry {
-    pub text: String,
+    pub turn_index: TurnIndex,
+    pub prompt: Prompt,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -16,15 +17,16 @@ pub struct TranscriptStore {
 }
 
 impl TranscriptStore {
-    pub fn append(&mut self, text: impl Into<String>) {
-        self.entries.push(TranscriptEntry { text: text.into() });
+    pub fn append(&mut self, prompt: Prompt) {
+        let turn_index = TurnIndex(self.entries.len());
+        self.entries.push(TranscriptEntry { turn_index, prompt });
         self.flushed = false;
     }
 
-    pub fn replay(&self) -> Vec<String> {
+    pub fn replay(&self) -> Vec<Prompt> {
         self.entries
             .iter()
-            .map(|entry| entry.text.clone())
+            .map(|entry| entry.prompt.clone())
             .collect()
     }
 
@@ -43,7 +45,7 @@ impl TranscriptStore {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionState {
     pub session_id: SessionId,
-    pub messages: Vec<String>,
+    pub messages: Vec<Prompt>,
     pub usage: UsageSummary,
 }
 
@@ -73,7 +75,7 @@ impl SessionStore {
 
     pub fn save(&self, session: &SessionState) -> Result<PathBuf, RuntimeError> {
         fs::create_dir_all(&self.root).map_err(|err| RuntimeError::Io(err.to_string()))?;
-        let path = self.root.join(format!("{}.json", session.session_id.0));
+        let path = self.root.join(format!("{}.json", session.session_id));
         let body = serde_json::to_string_pretty(session)
             .map_err(|err| RuntimeError::Serialization(err.to_string()))?;
         fs::write(&path, body).map_err(|err| RuntimeError::Io(err.to_string()))?;
@@ -82,7 +84,7 @@ impl SessionStore {
 
     pub fn load(&self, session_id: &str) -> Result<SessionState, RuntimeError> {
         let path = self.root.join(format!("{}.json", session_id));
-        if !Path::new(&path).exists() {
+        if !path.exists() {
             return Err(RuntimeError::SessionNotFound(session_id.to_string()));
         }
         let body = fs::read_to_string(&path).map_err(|err| RuntimeError::Io(err.to_string()))?;

--- a/crates/harness-tools/src/lib.rs
+++ b/crates/harness-tools/src/lib.rs
@@ -1,15 +1,15 @@
-use harness_core::PermissionDenial;
+use harness_core::{PermissionDenial, ToolName};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolDefinition {
-    pub name: String,
+    pub name: ToolName,
     pub description: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolResult {
-    pub name: String,
+    pub name: ToolName,
     pub handled: bool,
     pub message: String,
 }
@@ -26,8 +26,8 @@ impl PermissionPolicy {
         }
     }
 
-    pub fn denial_for(&self, tool_name: &str) -> Option<PermissionDenial> {
-        let lowered = tool_name.to_ascii_lowercase();
+    pub fn denial_for(&self, tool_name: &ToolName) -> Option<PermissionDenial> {
+        let lowered = tool_name.0.to_ascii_lowercase();
         self.denied_prefixes
             .iter()
             .find(|prefix| lowered.starts_with(&prefix.to_ascii_lowercase()))
@@ -35,6 +35,10 @@ impl PermissionPolicy {
                 subject: tool_name.to_string(),
                 reason: "tool blocked by permission policy".to_string(),
             })
+    }
+
+    pub fn denied_prefixes(&self) -> &[String] {
+        &self.denied_prefixes
     }
 }
 
@@ -48,15 +52,15 @@ impl ToolRegistry {
         Self {
             tools: vec![
                 ToolDefinition {
-                    name: "ReadFile".into(),
+                    name: ToolName::new("ReadFile"),
                     description: "Read a file from disk".into(),
                 },
                 ToolDefinition {
-                    name: "EditFile".into(),
+                    name: ToolName::new("EditFile"),
                     description: "Edit a file on disk".into(),
                 },
                 ToolDefinition {
-                    name: "Bash".into(),
+                    name: ToolName::new("Bash"),
                     description: "Execute shell commands".into(),
                 },
             ],
@@ -67,23 +71,11 @@ impl ToolRegistry {
         &self.tools
     }
 
-    pub fn find(&self, query: &str) -> Vec<ToolDefinition> {
-        let needle = query.to_ascii_lowercase();
-        self.tools
-            .iter()
-            .filter(|tool| {
-                tool.name.to_ascii_lowercase().contains(&needle)
-                    || tool.description.to_ascii_lowercase().contains(&needle)
-            })
-            .cloned()
-            .collect()
-    }
-
-    pub fn execute(&self, name: &str, payload: &str) -> ToolResult {
+    pub fn execute(&self, name: &ToolName, payload: &str) -> ToolResult {
         match self
             .tools
             .iter()
-            .find(|tool| tool.name.eq_ignore_ascii_case(name))
+            .find(|tool| tool.name.0.eq_ignore_ascii_case(&name.0))
         {
             Some(tool) => ToolResult {
                 name: tool.name.clone(),
@@ -91,7 +83,7 @@ impl ToolRegistry {
                 message: format!("tool '{}' would handle payload {:?}", tool.name, payload),
             },
             None => ToolResult {
-                name: name.to_string(),
+                name: name.clone(),
                 handled: false,
                 message: format!("unknown tool: {}", name),
             },


### PR DESCRIPTION
## Summary
- add typed core primitives for prompts, names, turn indices, and scores
- upgrade session, registry, and runtime layers to use typed models and structured routing
- wire the CLI through the typed runtime bootstrap path

## Validation
- cargo check
- cargo test
- cargo clippy --workspace --all-targets -- -D warnings
- cargo run -p harness-cli -- summary
- cargo run -p harness-cli -- route "review code and use bash"
- cargo run -p harness-cli -- bootstrap "review code and use bash"

Closes #1