### PR TITLE
test: add issue #10 CLI coverage baseline

### DIFF
--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -13,56 +13,56 @@ Rewrite the current repository into a Rust-native harness runtime that learns fr
 
 ## Phase 2 - Rust Workspace Bootstrap
 
-- [ ] Create workspace `Cargo.toml`
-- [ ] Create crates:
-  - [ ] `harness-core`
-  - [ ] `harness-session`
-  - [ ] `harness-tools`
-  - [ ] `harness-commands`
-  - [ ] `harness-runtime`
-  - [ ] `harness-cli`
-- [ ] Add shared dependencies (`serde`, `serde_json`, `clap`, `thiserror`, etc.)
-- [ ] Ensure `cargo check` passes
+- [x] Create workspace `Cargo.toml`
+- [x] Create crates:
+  - [x] `harness-core`
+  - [x] `harness-session`
+  - [x] `harness-tools`
+  - [x] `harness-commands`
+  - [x] `harness-runtime`
+  - [x] `harness-cli`
+- [x] Add shared dependencies (`serde`, `serde_json`, `clap`, `thiserror`, etc.)
+- [x] Ensure `cargo check` passes
 
 ## Phase 3 - Core Types
 
-- [ ] Implement ids and metadata types
-- [ ] Implement usage/accounting types
-- [ ] Implement error model
-- [ ] Implement event enums
+- [x] Implement ids and metadata types
+- [x] Implement usage/accounting types
+- [x] Implement error model
+- [x] Implement event enums
 
 ## Phase 4 - Session + Transcript
 
-- [ ] `SessionState`
-- [ ] `TranscriptEntry`
-- [ ] append/replay/compact
-- [ ] persistence to disk
-- [ ] session reload
+- [x] `SessionState`
+- [x] `TranscriptEntry`
+- [x] append/replay/compact
+- [x] persistence to disk
+- [x] session reload
 
 ## Phase 5 - Registries
 
-- [ ] Tool registry with metadata
-- [ ] Command registry with metadata
-- [ ] Search/filter/list APIs
-- [ ] Permission policy layer
+- [x] Tool registry with metadata
+- [x] Command registry with metadata
+- [x] Search/filter/list APIs
+- [x] Permission policy layer
 
 ## Phase 6 - Router + Runtime
 
-- [ ] Prompt tokenization
-- [ ] Match scoring
-- [ ] Deterministic ranking
-- [ ] Turn processor
-- [ ] Event emission
-- [ ] Session persistence after turn
+- [x] Prompt tokenization
+- [x] Match scoring
+- [x] Deterministic ranking
+- [x] Turn processor
+- [x] Event emission
+- [x] Session persistence after turn
 
 ## Phase 7 - CLI
 
-- [ ] `summary`
-- [ ] `route <prompt>`
-- [ ] `bootstrap <prompt>`
-- [ ] `tools list`
-- [ ] `commands list`
-- [ ] `session show <id>`
+- [x] `summary`
+- [x] `route <prompt>`
+- [x] `bootstrap <prompt>`
+- [x] `tools list`
+- [x] `commands list`
+- [x] `session show <id>`
 
 ## Phase 8 - Cleanup
 
@@ -81,9 +81,8 @@ Rewrite the current repository into a Rust-native harness runtime that learns fr
 
 ## Immediate Next Slice
 
-1. bootstrap Cargo workspace
-2. create core crates
-3. implement minimal typed models
-4. wire a first compiling CLI
-5. validate with `cargo check`
+1. remove obsolete Python-first scaffolding that no longer represents the active runtime lane
+2. add focused coverage for remaining zero-test crates or CLI route output
+3. expand README/examples for real CLI usage and validation flow
+4. keep each follow-up slice tied to a GitHub issue and PR
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repository already contains:
 - architecture and implementation planning docs
 - snapshot/reference material used to understand architectural surfaces
 
-The repository is still early. The real MVP runtime lane is tracked in issue #1.
+The repository is still early, but the Rust MVP lane is already partially implemented and tracked incrementally through the active GitHub issue queue.
 
 ## Workspace Layout
 
@@ -53,7 +53,7 @@ See:
 
 - `ARCHITECTURE.md`
 - `PORTING_PLAN.md`
-- issue #1
+- the active GitHub issue queue for the next atomic slice
 
 ## Quickstart
 
@@ -68,6 +68,7 @@ Run tests:
 ```bash
 cargo test -p harness-session
 cargo test -p harness-runtime
+cargo test -p harness-cli
 cargo test
 ```
 
@@ -91,16 +92,20 @@ Current protected Rust surface:
 - transcript compaction behavior in `harness-session`
 - deterministic route ordering in `harness-runtime`
 - bootstrap permission denial + session persistence behavior in `harness-runtime`
+- CLI summary output for the seeded runtime surface
+- CLI JSON inspection output for `tools` and `commands`
+- CLI persisted-session round trip through `bootstrap` + `session-show`
 
 Validation commands:
 
 ```bash
 cargo test -p harness-session
 cargo test -p harness-runtime
+cargo test -p harness-cli
 cargo test
 ```
 
-More runtime and CLI coverage will be added incrementally under issue #6.
+More runtime and CLI coverage should continue incrementally through the active issue queue.
 
 ## Development Workflow
 
@@ -119,9 +124,9 @@ This repo is a clean-room implementation effort informed by architectural study.
 
 - [x] architecture capture
 - [x] workspace bootstrap
-- [ ] core domain types
-- [ ] session/transcript persistence
-- [ ] registries
-- [ ] router/runtime loop
-- [ ] CLI inspection surface
+- [x] core domain types
+- [x] session/transcript persistence
+- [x] registries
+- [x] router/runtime loop
+- [x] CLI inspection surface
 - [ ] cleanup of obsolete Python-first scaffolding

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -20,49 +20,157 @@ enum CliCommand {
     SessionShow { id: String },
 }
 
-fn main() {
-    let cli = Cli::parse();
-    let engine = RuntimeEngine::default();
-
-    match cli.command {
-        CliCommand::Summary => {
-            println!("{}", engine.summary());
-        }
+fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
+    match command {
+        CliCommand::Summary => engine.summary(),
         CliCommand::Route { prompt } => {
             let matches = engine.route(&Prompt::new(prompt));
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&matches).expect("serialize route result")
-            );
+            serde_json::to_string_pretty(&matches).expect("serialize route result")
         }
         CliCommand::Bootstrap { prompt } => {
             let report = engine
                 .bootstrap(Prompt::new(prompt))
                 .expect("bootstrap runtime turn");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&report).expect("serialize bootstrap report")
-            );
+            serde_json::to_string_pretty(&report).expect("serialize bootstrap report")
         }
-        CliCommand::Tools => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(engine.tools.list()).expect("serialize tool list")
-            );
-        }
-        CliCommand::Commands => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(engine.commands.list())
-                    .expect("serialize command list")
-            );
-        }
+        CliCommand::Tools => serde_json::to_string_pretty(engine.tools.list())
+            .expect("serialize tool list"),
+        CliCommand::Commands => serde_json::to_string_pretty(engine.commands.list())
+            .expect("serialize command list"),
         CliCommand::SessionShow { id } => {
             let session = engine.load_session(&id).expect("load session by id");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&session).expect("serialize session")
-            );
+            serde_json::to_string_pretty(&session).expect("serialize session")
         }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let engine = RuntimeEngine::default();
+
+    println!("{}", render_command(&engine, cli.command));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_command, CliCommand};
+    use harness_commands::{CommandDefinition, CommandRegistry};
+    use harness_session::{SessionState, SessionStore};
+    use harness_tools::{PermissionPolicy, ToolDefinition, ToolRegistry};
+    use harness_runtime::RuntimeEngine;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_session_root() -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("harness-cli-tests-{nonce}"))
+    }
+
+    fn temp_engine(root: &PathBuf) -> RuntimeEngine {
+        RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(root),
+        }
+    }
+
+    #[test]
+    fn summary_renders_seeded_runtime_counts() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let output = render_command(&engine, CliCommand::Summary);
+
+        assert_eq!(output, "commands=3 tools=3 denied_prefixes=bash");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn tools_renders_seeded_tool_registry_json() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let output = render_command(&engine, CliCommand::Tools);
+        let tools: Vec<ToolDefinition> = serde_json::from_str(&output).expect("parse tool list");
+
+        let names: Vec<String> = tools.into_iter().map(|tool| tool.name.0).collect();
+        assert_eq!(
+            names,
+            vec![
+                "ReadFile".to_string(),
+                "EditFile".to_string(),
+                "Bash".to_string()
+            ]
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn commands_renders_seeded_command_registry_json() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let output = render_command(&engine, CliCommand::Commands);
+        let commands: Vec<CommandDefinition> =
+            serde_json::from_str(&output).expect("parse command list");
+
+        let names: Vec<String> = commands.into_iter().map(|command| command.name.0).collect();
+        assert_eq!(
+            names,
+            vec![
+                "review".to_string(),
+                "agents".to_string(),
+                "setup".to_string()
+            ]
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn bootstrap_then_session_show_round_trips_persisted_session_json() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let session_output = render_command(
+            &engine,
+            CliCommand::SessionShow {
+                id: session_id.clone(),
+            },
+        );
+        let session: SessionState =
+            serde_json::from_str(&session_output).expect("parse session-show output");
+
+        assert_eq!(session.session_id.to_string(), session_id);
+        assert_eq!(
+            session
+                .messages
+                .into_iter()
+                .map(|prompt| prompt.0)
+                .collect::<Vec<_>>(),
+            vec!["review bash".to_string()]
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
     }
 }


### PR DESCRIPTION
## Summary
- add `harness-cli` tests for the existing summary, tools, commands, and persisted-session inspection paths
- extract a small `render_command` helper so the current CLI surface is testable without changing runtime behavior
- sync `README.md` and `PORTING_PLAN.md` to the actual Rust MVP status and coverage baseline

## Validation
- cargo test -p harness-cli

Closes #10
