### PR TITLE
test: add issue #14 core registry coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ cargo check
 Run tests:
 
 ```bash
+cargo test -p harness-core
+cargo test -p harness-tools
+cargo test -p harness-commands
 cargo test -p harness-session
 cargo test -p harness-runtime
 cargo test -p harness-cli
@@ -86,6 +89,9 @@ cargo run -p harness-cli -- --help
 
 Current protected Rust surface:
 
+- `harness-core` prompt/name wrappers and token accounting helpers
+- seeded tool registry behavior plus permission-policy prefix denial in `harness-tools`
+- seeded command registry behavior in `harness-commands`
 - `harness-session` save/load round-trip persistence
 - transcript compaction behavior in `harness-session`
 - deterministic route ordering in `harness-runtime`
@@ -97,6 +103,9 @@ Current protected Rust surface:
 Validation commands:
 
 ```bash
+cargo test -p harness-core
+cargo test -p harness-tools
+cargo test -p harness-commands
 cargo test -p harness-session
 cargo test -p harness-runtime
 cargo test -p harness-cli

--- a/crates/harness-commands/src/lib.rs
+++ b/crates/harness-commands/src/lib.rs
@@ -65,3 +65,40 @@ impl CommandRegistry {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_registry_exposes_expected_command_names() {
+        let registry = CommandRegistry::seeded();
+        let names: Vec<_> = registry
+            .list()
+            .iter()
+            .map(|command| command.name.to_string())
+            .collect();
+
+        assert_eq!(names, vec!["review", "agents", "setup"]);
+    }
+
+    #[test]
+    fn execute_matches_seeded_commands_case_insensitively() {
+        let registry = CommandRegistry::seeded();
+        let result = registry.execute(&CommandName::new("REVIEW"), "review this PR");
+
+        assert!(result.handled);
+        assert_eq!(result.name.to_string(), "review");
+        assert!(result.message.contains("review this PR"));
+    }
+
+    #[test]
+    fn execute_reports_unknown_commands() {
+        let registry = CommandRegistry::seeded();
+        let result = registry.execute(&CommandName::new("deploy"), "ship it");
+
+        assert!(!result.handled);
+        assert_eq!(result.name.to_string(), "deploy");
+        assert_eq!(result.message, "unknown command: deploy");
+    }
+}

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -152,3 +152,33 @@ pub enum RuntimeError {
 pub fn estimate_tokens(text: &str) -> usize {
     text.split_whitespace().count().max(1)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_and_names_expose_string_views() {
+        let prompt = Prompt::new("review this diff");
+        let tool = ToolName::new("ReadFile");
+        let command = CommandName::new("review");
+
+        assert_eq!(prompt.as_str(), "review this diff");
+        assert_eq!(tool.to_string(), "ReadFile");
+        assert_eq!(command.to_string(), "review");
+    }
+
+    #[test]
+    fn usage_summary_accumulates_estimated_tokens() {
+        let usage = UsageSummary::default().add_turn("review this", "looks good");
+
+        assert_eq!(usage.input_tokens, 2);
+        assert_eq!(usage.output_tokens, 2);
+    }
+
+    #[test]
+    fn estimate_tokens_never_returns_zero() {
+        assert_eq!(estimate_tokens(""), 1);
+        assert_eq!(estimate_tokens("one two three"), 3);
+    }
+}

--- a/crates/harness-tools/src/lib.rs
+++ b/crates/harness-tools/src/lib.rs
@@ -90,3 +90,46 @@ impl ToolRegistry {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_registry_exposes_expected_tool_names() {
+        let registry = ToolRegistry::seeded();
+        let names: Vec<_> = registry
+            .list()
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+
+        assert_eq!(names, vec!["ReadFile", "EditFile", "Bash"]);
+    }
+
+    #[test]
+    fn execute_matches_seeded_tools_case_insensitively() {
+        let registry = ToolRegistry::seeded();
+        let result = registry.execute(&ToolName::new("bash"), "ls -la");
+
+        assert!(result.handled);
+        assert_eq!(result.name.to_string(), "Bash");
+        assert!(result.message.contains("ls -la"));
+    }
+
+    #[test]
+    fn permission_policy_denies_matching_prefixes_case_insensitively() {
+        let policy = PermissionPolicy::with_denied_prefixes(["bash", "edit"]);
+        let denial = policy.denial_for(&ToolName::new("BashInteractive"));
+
+        assert_eq!(policy.denied_prefixes(), &["bash".to_string(), "edit".to_string()]);
+        assert_eq!(
+            denial,
+            Some(PermissionDenial {
+                subject: "BashInteractive".to_string(),
+                reason: "tool blocked by permission policy".to_string(),
+            })
+        );
+        assert_eq!(policy.denial_for(&ToolName::new("ReadFile")), None);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused Rust tests to `harness-core` for prompt/name wrappers and token accounting helpers
- add seeded registry and permission policy coverage to `harness-tools`
- add seeded registry coverage to `harness-commands` and update the README test baseline

## Validation
- cargo test -p harness-core
- cargo test -p harness-tools
- cargo test -p harness-commands

Closes #14
