### PR TITLE
test: add issue #18 CLI route regression

### DIFF
--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -81,7 +81,7 @@ Rewrite the current repository into a Rust-native harness runtime that learns fr
 
 ## Immediate Next Slice
 
-1. add focused coverage for CLI `route` output or example-driven CLI docs regression tests
-2. decide whether `src/reference_data/` should remain in-tree or move under a clearer archival path
+1. decide whether `src/reference_data/` should remain in-tree or move under a clearer archival path
+2. add example-driven CLI docs regression tests if the visible CLI surface grows beyond the current baseline
 3. expand README/ARCHITECTURE examples if the CLI surface changes
 4. keep each follow-up slice tied to a GitHub issue and PR

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Current protected Rust surface:
 - deterministic route ordering in `harness-runtime`
 - bootstrap permission denial + session persistence behavior in `harness-runtime`
 - CLI summary output for the seeded runtime surface
+- CLI deterministic JSON output for `route <prompt>`
 - CLI JSON inspection output for `tools` and `commands`
 - CLI persisted-session round trip through `bootstrap` + `session-show`
 

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -92,6 +92,38 @@ mod tests {
     }
 
     #[test]
+    fn route_renders_seeded_runtime_matches_json() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let output = render_command(
+            &engine,
+            CliCommand::Route {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let routed: serde_json::Value = serde_json::from_str(&output).expect("parse route output");
+
+        assert_eq!(
+            routed,
+            serde_json::json!([
+                {
+                    "kind": "command",
+                    "name": "review",
+                    "score": 1
+                },
+                {
+                    "kind": "tool",
+                    "name": "Bash",
+                    "score": 1
+                }
+            ])
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn tools_renders_seeded_tool_registry_json() {
         let root = temp_session_root();
         let engine = temp_engine(&root);


### PR DESCRIPTION
## Summary
- add focused `harness-cli` regression coverage for `route <prompt>` output
- record the new CLI route baseline in the README coverage section
- update `PORTING_PLAN.md` so the next-slice list reflects that route-output coverage is now done

## Validation
- cargo test -p harness-cli

Closes #18
