### PR TITLE
feat: add issue #26 session recency UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,8 +179,9 @@ Session and transcript concerns:
 - `TranscriptEntry`
 - `TranscriptStore`
 - `SessionStore`
+- recency metadata for persisted sessions
 - compaction policy
-- disk persistence/load/list
+- disk persistence/load/list/latest
 
 ### harness-tools
 Tool concerns:
@@ -216,8 +217,9 @@ User-facing CLI:
 - `bootstrap <prompt>`
 - `tools list`
 - `commands list`
-- `sessions`
+- `sessions` (newest-first)
 - `session show <id>`
+- `session show latest`
 
 ## Structured Event Model
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cargo run -p harness-cli -- --help
 
 ## CLI Usage Examples
 
-The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses the stable placeholder `<session-id>` (and matching persisted path) for the generated values that vary per run.
+The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses stable placeholders for generated values that vary per run: `<session-id>` for ids, `<created-at-ms>` for persisted recency metadata, and matching `.sessions/<session-id>.json` paths.
 
 ### `summary`
 
@@ -180,6 +180,7 @@ cargo run -q -p harness-cli -- bootstrap "review bash"
 {
   "session": {
     "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
     "messages": [
       "review bash"
     ],
@@ -293,6 +294,7 @@ cargo run -q -p harness-cli -- sessions
 [
   {
     "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
     "message_count": 1,
     "persisted_path": ".sessions/<session-id>.json"
   }
@@ -308,6 +310,27 @@ cargo run -q -p harness-cli -- session-show <session-id>
 ```json
 {
   "session_id": "<session-id>",
+  "created_at_ms": <created-at-ms>,
+  "messages": [
+    "review bash"
+  ],
+  "usage": {
+    "input_tokens": 2,
+    "output_tokens": 2
+  }
+}
+```
+
+### `session-show latest`
+
+```bash
+cargo run -q -p harness-cli -- session-show latest
+```
+
+```json
+{
+  "session_id": "<session-id>",
+  "created_at_ms": <created-at-ms>,
   "messages": [
     "review bash"
   ],
@@ -329,9 +352,9 @@ Current protected Rust surface:
 - transcript compaction behavior in `harness-session`
 - deterministic route ordering in `harness-runtime`
 - bootstrap permission denial + session persistence behavior in `harness-runtime`
-- `harness-session` deterministic persisted-session listing metadata
+- `harness-session` recency metadata, newest-first listing, and latest-session lookup
 - README-backed CLI output regression coverage for `summary`, `route <prompt>`, `tools`, `commands`, and `sessions`
-- README-backed persisted-session example coverage for `bootstrap <prompt>` and `session-show <id>`, with generated session identifiers normalized to `<session-id>` in test assertions
+- README-backed persisted-session example coverage for `bootstrap <prompt>`, `session-show <id>`, and `session-show latest`, with generated session identifiers normalized to `<session-id>` and generated recency metadata normalized to `<created-at-ms>` in test assertions
 
 Validation commands:
 

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -113,14 +113,35 @@ mod tests {
             .to_string()
     }
 
+    fn normalize_created_at_ms(output: &str) -> String {
+        let marker = "\"created_at_ms\": ";
+        if let Some(start) = output.find(marker) {
+            let value_start = start + marker.len();
+            let value_end = output[value_start..]
+                .find(|ch: char| !ch.is_ascii_digit())
+                .map(|offset| value_start + offset)
+                .unwrap_or(output.len());
+
+            let mut normalized = String::with_capacity(output.len());
+            normalized.push_str(&output[..value_start]);
+            normalized.push_str("<created-at-ms>");
+            normalized.push_str(&output[value_end..]);
+            normalized
+        } else {
+            output.to_string()
+        }
+    }
+
     fn normalize_bootstrap_example(output: &str, session_id: &str, root: &PathBuf) -> String {
-        output
-            .replace(session_id, "<session-id>")
-            .replace(root.to_string_lossy().as_ref(), ".sessions")
+        normalize_created_at_ms(
+            &output
+                .replace(session_id, "<session-id>")
+                .replace(root.to_string_lossy().as_ref(), ".sessions"),
+        )
     }
 
     fn normalize_session_output(output: &str, session_id: &str) -> String {
-        output.replace(session_id, "<session-id>")
+        normalize_created_at_ms(&output.replace(session_id, "<session-id>"))
     }
 
     #[test]
@@ -243,6 +264,39 @@ mod tests {
         assert_eq!(
             normalize_session_output(&session_output, &session_id),
             readme_output_block("session-show <id>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_show_latest_matches_readme_example() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let latest_output = render_command(
+            &engine,
+            CliCommand::SessionShow {
+                id: "latest".to_string(),
+            },
+        );
+
+        assert_eq!(
+            normalize_session_output(&latest_output, &session_id),
+            readme_output_block("session-show latest", "json")
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -226,6 +226,10 @@ impl RuntimeEngine {
     }
 
     pub fn load_session(&self, id: &str) -> Result<SessionState, String> {
+        if id == "latest" {
+            return self.store.latest().map_err(|err| err.to_string());
+        }
+
         self.store.load(id).map_err(|err| err.to_string())
     }
 }

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -1,8 +1,16 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use harness_core::{Prompt, RuntimeError, SessionId, TurnIndex, UsageSummary};
 use serde::{Deserialize, Serialize};
+
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_millis() as u64
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TranscriptEntry {
@@ -45,6 +53,8 @@ impl TranscriptStore {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionState {
     pub session_id: SessionId,
+    #[serde(default = "current_timestamp_ms")]
+    pub created_at_ms: u64,
     pub messages: Vec<Prompt>,
     pub usage: UsageSummary,
 }
@@ -53,6 +63,7 @@ impl Default for SessionState {
     fn default() -> Self {
         Self {
             session_id: SessionId::new(),
+            created_at_ms: current_timestamp_ms(),
             messages: Vec::new(),
             usage: UsageSummary::default(),
         }
@@ -62,6 +73,7 @@ impl Default for SessionState {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionListing {
     pub session_id: SessionId,
+    pub created_at_ms: u64,
     pub message_count: usize,
     pub persisted_path: String,
 }
@@ -98,6 +110,15 @@ impl SessionStore {
         serde_json::from_str(&body).map_err(|err| RuntimeError::Serialization(err.to_string()))
     }
 
+    pub fn latest(&self) -> Result<SessionState, RuntimeError> {
+        let latest = self
+            .list()?
+            .into_iter()
+            .next()
+            .ok_or_else(|| RuntimeError::SessionNotFound("latest".to_string()))?;
+        self.load(&latest.session_id.to_string())
+    }
+
     pub fn list(&self) -> Result<Vec<SessionListing>, RuntimeError> {
         if !self.root.exists() {
             return Ok(Vec::new());
@@ -122,15 +143,17 @@ impl SessionStore {
 
             sessions.push(SessionListing {
                 session_id: session.session_id,
+                created_at_ms: session.created_at_ms,
                 message_count: session.messages.len(),
                 persisted_path: path.display().to_string(),
             });
         }
 
         sessions.sort_by(|left, right| {
-            left.session_id
-                .to_string()
-                .cmp(&right.session_id.to_string())
+            right
+                .created_at_ms
+                .cmp(&left.created_at_ms)
+                .then_with(|| left.session_id.to_string().cmp(&right.session_id.to_string()))
                 .then_with(|| left.persisted_path.cmp(&right.persisted_path))
         });
 
@@ -160,6 +183,7 @@ mod tests {
         let store = SessionStore::new(&root);
         let session = SessionState {
             session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_001,
             messages: vec![Prompt::new("review the runtime lane")],
             usage: harness_core::UsageSummary {
                 input_tokens: 4,
@@ -198,19 +222,21 @@ mod tests {
     }
 
     #[test]
-    fn lists_persisted_sessions_deterministically() {
+    fn lists_persisted_sessions_newest_first() {
         let root = temp_session_root();
         let store = SessionStore::new(&root);
-        let first = SessionState {
+        let older = SessionState {
             session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_000,
             messages: vec![Prompt::new("review bash")],
             usage: harness_core::UsageSummary {
                 input_tokens: 2,
                 output_tokens: 2,
             },
         };
-        let second = SessionState {
+        let newer = SessionState {
             session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_100,
             messages: vec![Prompt::new("summary"), Prompt::new("tools")],
             usage: harness_core::UsageSummary {
                 input_tokens: 2,
@@ -218,8 +244,8 @@ mod tests {
             },
         };
 
-        store.save(&first).expect("save first session");
-        store.save(&second).expect("save second session");
+        store.save(&older).expect("save older session");
+        store.save(&newer).expect("save newer session");
         fs::write(root.join("notes.txt"), "ignore me").expect("write non-session fixture");
 
         let listed = store.list().expect("list persisted sessions");
@@ -227,35 +253,75 @@ mod tests {
             .iter()
             .map(|session| session.session_id.to_string())
             .collect();
-        let mut expected_ids = vec![first.session_id.to_string(), second.session_id.to_string()];
-        expected_ids.sort();
 
-        assert_eq!(listed_ids, expected_ids);
+        assert_eq!(
+            listed_ids,
+            vec![newer.session_id.to_string(), older.session_id.to_string()]
+        );
 
-        let by_id: BTreeMap<String, (usize, String)> = listed
+        let by_id: BTreeMap<String, (u64, usize, String)> = listed
             .into_iter()
             .map(|session| {
                 (
                     session.session_id.to_string(),
-                    (session.message_count, session.persisted_path),
+                    (
+                        session.created_at_ms,
+                        session.message_count,
+                        session.persisted_path,
+                    ),
                 )
             })
             .collect();
 
-        assert_eq!(by_id[&first.session_id.to_string()].0, 1);
-        assert_eq!(by_id[&second.session_id.to_string()].0, 2);
+        assert_eq!(by_id[&older.session_id.to_string()].0, older.created_at_ms);
+        assert_eq!(by_id[&newer.session_id.to_string()].0, newer.created_at_ms);
+        assert_eq!(by_id[&older.session_id.to_string()].1, 1);
+        assert_eq!(by_id[&newer.session_id.to_string()].1, 2);
         assert_eq!(
-            by_id[&first.session_id.to_string()].1,
-            root.join(format!("{}.json", first.session_id))
+            by_id[&older.session_id.to_string()].2,
+            root.join(format!("{}.json", older.session_id))
                 .display()
                 .to_string()
         );
         assert_eq!(
-            by_id[&second.session_id.to_string()].1,
-            root.join(format!("{}.json", second.session_id))
+            by_id[&newer.session_id.to_string()].2,
+            root.join(format!("{}.json", newer.session_id))
                 .display()
                 .to_string()
         );
+
+        fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn loads_latest_persisted_session() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+        let older = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_000,
+            messages: vec![Prompt::new("review bash")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 2,
+                output_tokens: 2,
+            },
+        };
+        let newer = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_100,
+            messages: vec![Prompt::new("summary")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+        };
+
+        store.save(&older).expect("save older session");
+        store.save(&newer).expect("save newer session");
+
+        let latest = store.latest().expect("load latest session");
+
+        assert_eq!(latest, newer);
 
         fs::remove_dir_all(&root).expect("remove temp session test directory");
     }


### PR DESCRIPTION
## Summary
- add persisted session recency metadata and newest-first session listing
- support `session-show latest` as an ergonomic latest-session inspection path
- sync README/architecture docs and regression coverage with the updated session inspection surface

## Validation
- cargo test -p harness-session
- cargo test -p harness-cli

## Issue
- closes #26
