### PR TITLE
feat: CLI session resume for persisted sessions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,9 +179,9 @@ Session and transcript concerns:
 - `TranscriptEntry`
 - `TranscriptStore`
 - `SessionStore`
-- recency metadata for persisted sessions
+- recency metadata for persisted sessions (`created_at_ms`) plus activity metadata (`updated_at_ms`) that bumps on resume so `latest` follows the most recently active session
 - compaction policy
-- disk persistence/load/list/latest
+- disk persistence/load/list/latest/resume-aware ordering
 
 ### harness-tools
 Tool concerns:
@@ -215,6 +215,7 @@ User-facing CLI:
 - `summary`
 - `route <prompt>`
 - `bootstrap <prompt>`
+- `resume <id> <prompt>` and `resume latest <prompt>` (append a new turn to an existing persisted session; output confirms the targeted session id and appended turn index)
 - `tools list`
 - `commands list`
 - `sessions` (newest-first)
@@ -226,6 +227,7 @@ User-facing CLI:
 The Rust runtime should expose a typed event stream. First event set:
 
 - `SessionStarted`
+- `SessionResumed`
 - `PromptReceived`
 - `RouteComputed`
 - `CommandMatched`

--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -60,6 +60,7 @@ Build a Rust-native Claude Code-style CLI/runtime that Hamza can use as a primar
 - [x] `summary`
 - [x] `route <prompt>`
 - [x] `bootstrap <prompt>`
+- [x] `resume <id> <prompt>` (and `resume latest <prompt>`) — append a new turn to an existing persisted session; output confirms the targeted session id, the appended turn index, and the refreshed `updated_at_ms` activity metadata
 - [x] `tools`
 - [x] `commands`
 - [x] `session-show <id>`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The first meaningful milestone is:
 - tool and command registries
 - deterministic routing
 - runtime turn processor with structured events
-- CLI commands for summary, route, bootstrap, tools, commands, session listing, and session inspection
+- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, and session inspection
 
 See:
 
@@ -91,7 +91,7 @@ cargo run -p harness-cli -- --help
 
 ## CLI Usage Examples
 
-The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses stable placeholders for generated values that vary per run: `<session-id>` for ids, `<created-at-ms>` for persisted recency metadata, and matching `.sessions/<session-id>.json` paths.
+The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses stable placeholders for generated values that vary per run: `<session-id>` for ids, `<created-at-ms>` and `<updated-at-ms>` for persisted recency/activity metadata, and matching `.sessions/<session-id>.json` paths.
 
 ### `summary`
 
@@ -181,6 +181,7 @@ cargo run -q -p harness-cli -- bootstrap "review bash"
   "session": {
     "session_id": "<session-id>",
     "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
     "messages": [
       "review bash"
     ],
@@ -284,6 +285,115 @@ cargo run -q -p harness-cli -- bootstrap "review bash"
 }
 ```
 
+### `resume <id> "review summary"`
+
+Append a new turn to an existing persisted session. Pass either an explicit session id or the literal `latest` target. The resumed turn is appended to the same session file rather than starting a new session, and `updated_at_ms` is refreshed so subsequent `latest` lookups point at the most recently active session.
+
+```bash
+cargo run -q -p harness-cli -- resume <session-id> "review summary"
+```
+
+```json
+{
+  "resumed_session_id": "<session-id>",
+  "appended_turn_index": 1,
+  "session": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "messages": [
+      "review bash",
+      "review summary"
+    ],
+    "usage": {
+      "input_tokens": 4,
+      "output_tokens": 4
+    }
+  },
+  "transcript": {
+    "entries": [
+      {
+        "turn_index": 0,
+        "prompt": "review bash"
+      },
+      {
+        "turn_index": 1,
+        "prompt": "review summary"
+      }
+    ],
+    "flushed": true
+  },
+  "matches": [
+    {
+      "kind": "command",
+      "name": "review",
+      "score": 1
+    }
+  ],
+  "denials": [],
+  "command_results": [
+    {
+      "name": "review",
+      "handled": true,
+      "message": "command 'review' would handle prompt \"review summary\""
+    }
+  ],
+  "tool_results": [],
+  "events": [
+    {
+      "SessionResumed": {
+        "session_id": "<session-id>",
+        "turn_index": 1
+      }
+    },
+    {
+      "PromptReceived": {
+        "prompt": "review summary"
+      }
+    },
+    {
+      "RouteComputed": {
+        "match_count": 1
+      }
+    },
+    {
+      "CommandMatched": {
+        "name": "review",
+        "score": 1
+      }
+    },
+    {
+      "CommandInvoked": {
+        "name": "review"
+      }
+    },
+    {
+      "CommandCompleted": {
+        "name": "review",
+        "handled": true
+      }
+    },
+    {
+      "TurnCompleted": {
+        "stop_reason": "completed"
+      }
+    },
+    {
+      "SessionPersisted": {
+        "path": ".sessions/<session-id>.json"
+      }
+    }
+  ],
+  "persisted_path": ".sessions/<session-id>.json"
+}
+```
+
+`latest` is supported as the resume target too:
+
+```bash
+cargo run -q -p harness-cli -- resume latest "review summary"
+```
+
 ### `sessions`
 
 ```bash
@@ -295,6 +405,7 @@ cargo run -q -p harness-cli -- sessions
   {
     "session_id": "<session-id>",
     "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
     "message_count": 1,
     "persisted_path": ".sessions/<session-id>.json"
   }
@@ -311,6 +422,7 @@ cargo run -q -p harness-cli -- session-show <session-id>
 {
   "session_id": "<session-id>",
   "created_at_ms": <created-at-ms>,
+  "updated_at_ms": <updated-at-ms>,
   "messages": [
     "review bash"
   ],
@@ -331,6 +443,7 @@ cargo run -q -p harness-cli -- session-show latest
 {
   "session_id": "<session-id>",
   "created_at_ms": <created-at-ms>,
+  "updated_at_ms": <updated-at-ms>,
   "messages": [
     "review bash"
   ],
@@ -352,9 +465,11 @@ Current protected Rust surface:
 - transcript compaction behavior in `harness-session`
 - deterministic route ordering in `harness-runtime`
 - bootstrap permission denial + session persistence behavior in `harness-runtime`
-- `harness-session` recency metadata, newest-first listing, and latest-session lookup
+- `harness-session` recency metadata, newest-first listing, latest-session lookup, and activity-ordered `latest` after a persisted session is resumed
 - README-backed CLI output regression coverage for `summary`, `route <prompt>`, `tools`, `commands`, and `sessions`
-- README-backed persisted-session example coverage for `bootstrap <prompt>`, `session-show <id>`, and `session-show latest`, with generated session identifiers normalized to `<session-id>` and generated recency metadata normalized to `<created-at-ms>` in test assertions
+- README-backed persisted-session example coverage for `bootstrap <prompt>`, `session-show <id>`, and `session-show latest`, with generated session identifiers normalized to `<session-id>` and generated recency metadata normalized to `<created-at-ms>` / `<updated-at-ms>` in test assertions
+- `harness-runtime` session resume behavior: an appended turn targets the original session id, bumps `updated_at_ms`, and emits a `SessionResumed` event; `resume latest` targets the most recently active session
+- README-backed CLI coverage for `resume <id> "review summary"` confirming the resumed turn is appended to the existing persisted session and the output exposes the targeted session id plus the appended turn index
 
 Validation commands:
 
@@ -409,3 +524,4 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] CLI usage examples and validation flow
 - [x] cleanup of obsolete Python-first scaffolding
 - [x] move retained architecture-study snapshots under `archive/reference_data/`
+- [x] CLI session resume for persisted sessions (explicit id and `latest`)

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -15,6 +15,7 @@ enum CliCommand {
     Summary,
     Route { prompt: String },
     Bootstrap { prompt: String },
+    Resume { id: String, prompt: String },
     Tools,
     Commands,
     Sessions,
@@ -33,6 +34,12 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
                 .bootstrap(Prompt::new(prompt))
                 .expect("bootstrap runtime turn");
             serde_json::to_string_pretty(&report).expect("serialize bootstrap report")
+        }
+        CliCommand::Resume { id, prompt } => {
+            let report = engine
+                .resume(&id, Prompt::new(prompt))
+                .expect("resume persisted session");
+            serde_json::to_string_pretty(&report).expect("serialize resume report")
         }
         CliCommand::Tools => {
             serde_json::to_string_pretty(engine.tools.list()).expect("serialize tool list")
@@ -66,7 +73,7 @@ mod tests {
     use harness_session::{SessionState, SessionStore};
     use harness_tools::{PermissionPolicy, ToolRegistry};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const README: &str = include_str!("../../../README.md");
@@ -79,7 +86,7 @@ mod tests {
         std::env::temp_dir().join(format!("harness-cli-tests-{nonce}"))
     }
 
-    fn temp_engine(root: &PathBuf) -> RuntimeEngine {
+    fn temp_engine(root: &Path) -> RuntimeEngine {
         RuntimeEngine {
             commands: CommandRegistry::seeded(),
             tools: ToolRegistry::seeded(),
@@ -113,27 +120,32 @@ mod tests {
             .to_string()
     }
 
-    fn normalize_created_at_ms(output: &str) -> String {
-        let marker = "\"created_at_ms\": ";
-        if let Some(start) = output.find(marker) {
+    fn normalize_timestamp_field(output: &str, field: &str, placeholder: &str) -> String {
+        let marker = format!("\"{field}\": ");
+        let mut remaining = output;
+        let mut normalized = String::with_capacity(output.len());
+        while let Some(start) = remaining.find(&marker) {
             let value_start = start + marker.len();
-            let value_end = output[value_start..]
+            let value_end = remaining[value_start..]
                 .find(|ch: char| !ch.is_ascii_digit())
                 .map(|offset| value_start + offset)
-                .unwrap_or(output.len());
+                .unwrap_or(remaining.len());
 
-            let mut normalized = String::with_capacity(output.len());
-            normalized.push_str(&output[..value_start]);
-            normalized.push_str("<created-at-ms>");
-            normalized.push_str(&output[value_end..]);
-            normalized
-        } else {
-            output.to_string()
+            normalized.push_str(&remaining[..value_start]);
+            normalized.push_str(placeholder);
+            remaining = &remaining[value_end..];
         }
+        normalized.push_str(remaining);
+        normalized
     }
 
-    fn normalize_bootstrap_example(output: &str, session_id: &str, root: &PathBuf) -> String {
-        normalize_created_at_ms(
+    fn normalize_timestamps(output: &str) -> String {
+        let stage_one = normalize_timestamp_field(output, "created_at_ms", "<created-at-ms>");
+        normalize_timestamp_field(&stage_one, "updated_at_ms", "<updated-at-ms>")
+    }
+
+    fn normalize_bootstrap_example(output: &str, session_id: &str, root: &Path) -> String {
+        normalize_timestamps(
             &output
                 .replace(session_id, "<session-id>")
                 .replace(root.to_string_lossy().as_ref(), ".sessions"),
@@ -141,7 +153,7 @@ mod tests {
     }
 
     fn normalize_session_output(output: &str, session_id: &str) -> String {
-        normalize_created_at_ms(&output.replace(session_id, "<session-id>"))
+        normalize_timestamps(&output.replace(session_id, "<session-id>"))
     }
 
     #[test]
@@ -264,6 +276,72 @@ mod tests {
         assert_eq!(
             normalize_session_output(&session_output, &session_id),
             readme_output_block("session-show <id>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn resume_matches_readme_example_and_targets_existing_session() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let resume_output = render_command(
+            &engine,
+            CliCommand::Resume {
+                id: session_id.clone(),
+                prompt: "review summary".to_string(),
+            },
+        );
+
+        let resume_json: serde_json::Value =
+            serde_json::from_str(&resume_output).expect("parse resume report");
+        assert_eq!(
+            resume_json["resumed_session_id"].as_str(),
+            Some(session_id.as_str()),
+            "resume report must confirm the targeted session id"
+        );
+        assert_eq!(
+            resume_json["appended_turn_index"].as_u64(),
+            Some(1),
+            "resume report must expose the appended turn index"
+        );
+
+        assert_eq!(
+            normalize_bootstrap_example(&resume_output, &session_id, &root),
+            readme_output_block("resume <id> \"review summary\"", "json")
+        );
+
+        let reloaded_output = render_command(
+            &engine,
+            CliCommand::SessionShow {
+                id: session_id.clone(),
+            },
+        );
+        let reloaded: SessionState =
+            serde_json::from_str(&reloaded_output).expect("parse reloaded session");
+        let reloaded_messages: Vec<String> = reloaded
+            .messages
+            .iter()
+            .map(|prompt| prompt.0.clone())
+            .collect();
+        assert_eq!(
+            reloaded_messages,
+            vec!["review bash".to_string(), "review summary".to_string()],
+            "resume must append to the existing persisted session"
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -99,6 +99,10 @@ pub enum RuntimeEvent {
     SessionStarted {
         session_id: SessionId,
     },
+    SessionResumed {
+        session_id: SessionId,
+        turn_index: TurnIndex,
+    },
     PromptReceived {
         prompt: Prompt,
     },

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 use harness_commands::{CommandRegistry, CommandResult};
 use harness_core::{
-    CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName,
+    CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName, TurnIndex,
 };
 use harness_session::{SessionListing, SessionState, SessionStore, TranscriptStore};
 use harness_tools::{PermissionPolicy, ToolRegistry, ToolResult};
@@ -22,6 +22,20 @@ pub struct RoutedMatch {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TurnReport {
+    pub session: SessionState,
+    pub transcript: TranscriptStore,
+    pub matches: Vec<RoutedMatch>,
+    pub denials: Vec<PermissionDenial>,
+    pub command_results: Vec<CommandResult>,
+    pub tool_results: Vec<ToolResult>,
+    pub events: Vec<RuntimeEvent>,
+    pub persisted_path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResumeReport {
+    pub resumed_session_id: SessionId,
+    pub appended_turn_index: TurnIndex,
     pub session: SessionState,
     pub transcript: TranscriptStore,
     pub matches: Vec<RoutedMatch>,
@@ -221,6 +235,122 @@ impl RuntimeEngine {
         })
     }
 
+    pub fn resume(&self, target: &str, prompt: Prompt) -> Result<ResumeReport, String> {
+        let mut session = self.load_session(target)?;
+        let resumed_session_id = session.session_id.clone();
+
+        let mut transcript = TranscriptStore::default();
+        for existing in &session.messages {
+            transcript.append(existing.clone());
+        }
+
+        let appended_turn_index = TurnIndex(session.messages.len());
+        let mut events = vec![RuntimeEvent::SessionResumed {
+            session_id: resumed_session_id.clone(),
+            turn_index: appended_turn_index,
+        }];
+        events.push(RuntimeEvent::PromptReceived {
+            prompt: prompt.clone(),
+        });
+
+        let matches = self.route(&prompt);
+        events.push(RuntimeEvent::RouteComputed {
+            match_count: matches.len(),
+        });
+
+        for matched in &matches {
+            match matched.kind {
+                MatchKind::Command => events.push(RuntimeEvent::CommandMatched {
+                    name: CommandName::new(matched.name.clone()),
+                    score: matched.score,
+                }),
+                MatchKind::Tool => events.push(RuntimeEvent::ToolMatched {
+                    name: ToolName::new(matched.name.clone()),
+                    score: matched.score,
+                }),
+            }
+        }
+
+        let denials: Vec<PermissionDenial> = matches
+            .iter()
+            .filter(|matched| matched.kind == MatchKind::Tool)
+            .filter_map(|matched| {
+                self.permissions
+                    .denial_for(&ToolName::new(matched.name.clone()))
+            })
+            .collect();
+
+        for denial in &denials {
+            events.push(RuntimeEvent::PermissionDenied {
+                subject: denial.subject.clone(),
+                reason: denial.reason.clone(),
+            });
+        }
+
+        let command_results: Vec<CommandResult> = matches
+            .iter()
+            .filter(|matched| matched.kind == MatchKind::Command)
+            .map(|matched| {
+                let name = CommandName::new(matched.name.clone());
+                events.push(RuntimeEvent::CommandInvoked { name: name.clone() });
+                let result = self.commands.execute(&name, prompt.as_str());
+                events.push(RuntimeEvent::CommandCompleted {
+                    name,
+                    handled: result.handled,
+                });
+                result
+            })
+            .collect();
+
+        let tool_results: Vec<ToolResult> = matches
+            .iter()
+            .filter(|matched| matched.kind == MatchKind::Tool)
+            .filter(|matched| {
+                self.permissions
+                    .denial_for(&ToolName::new(matched.name.clone()))
+                    .is_none()
+            })
+            .map(|matched| {
+                let name = ToolName::new(matched.name.clone());
+                events.push(RuntimeEvent::ToolInvoked { name: name.clone() });
+                let result = self.tools.execute(&name, prompt.as_str());
+                events.push(RuntimeEvent::ToolCompleted {
+                    name,
+                    handled: result.handled,
+                });
+                result
+            })
+            .collect();
+
+        session.messages.push(prompt.clone());
+        session.usage = session.usage.add_turn(prompt.as_str(), "turn completed");
+        session.touch();
+        transcript.append(prompt);
+        transcript.flush();
+
+        events.push(RuntimeEvent::TurnCompleted {
+            stop_reason: "completed".into(),
+        });
+
+        let persisted_path = self.store.save(&session).map_err(|err| err.to_string())?;
+        events.push(RuntimeEvent::SessionPersisted {
+            path: persisted_path.display().to_string(),
+        });
+
+        Ok(ResumeReport {
+            resumed_session_id,
+            appended_turn_index,
+            session,
+            transcript,
+            matches,
+            denials,
+            command_results,
+            tool_results,
+            events,
+            persisted_path: persisted_path.display().to_string(),
+        })
+    }
+
     pub fn list_sessions(&self) -> Result<Vec<SessionListing>, String> {
         self.store.list().map_err(|err| err.to_string())
     }
@@ -271,6 +401,105 @@ mod tests {
                 (MatchKind::Tool, "ReadFile".to_string(), 1),
             ]
         );
+    }
+
+    #[test]
+    fn resume_appends_to_existing_session_and_emits_resume_event() {
+        use harness_core::{Prompt, RuntimeEvent, TurnIndex};
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let bootstrap = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap session");
+        let original_id = bootstrap.session.session_id.to_string();
+        let original_updated = bootstrap.session.updated_at_ms;
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let resumed = engine
+            .resume(&original_id, Prompt::new("summary please"))
+            .expect("resume existing session");
+
+        assert_eq!(resumed.resumed_session_id.to_string(), original_id);
+        assert_eq!(resumed.appended_turn_index, TurnIndex(1));
+        assert_eq!(resumed.session.session_id.to_string(), original_id);
+        assert_eq!(
+            resumed
+                .session
+                .messages
+                .iter()
+                .map(|prompt| prompt.0.clone())
+                .collect::<Vec<_>>(),
+            vec!["review bash".to_string(), "summary please".to_string()]
+        );
+        assert_eq!(resumed.session.created_at_ms, bootstrap.session.created_at_ms);
+        assert!(resumed.session.updated_at_ms >= original_updated);
+
+        assert!(resumed.events.iter().any(|event| matches!(
+            event,
+            RuntimeEvent::SessionResumed { session_id, turn_index }
+                if session_id.to_string() == original_id && *turn_index == TurnIndex(1)
+        )));
+        assert!(resumed.transcript.flushed);
+        assert_eq!(resumed.transcript.entries.len(), 2);
+
+        let reloaded = engine
+            .load_session(&original_id)
+            .expect("reload resumed session");
+        assert_eq!(reloaded, resumed.session);
+
+        let latest = engine
+            .load_session("latest")
+            .expect("latest should resolve to resumed session");
+        assert_eq!(latest.session_id.to_string(), original_id);
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn resume_latest_targets_most_recently_active_session() {
+        use harness_core::Prompt;
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let first = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap first session");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let _second = engine
+            .bootstrap(Prompt::new("summary"))
+            .expect("bootstrap second session");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let resumed = engine
+            .resume(&first.session.session_id.to_string(), Prompt::new("follow up"))
+            .expect("resume first session");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let resumed_via_latest = engine
+            .resume("latest", Prompt::new("one more"))
+            .expect("resume via latest");
+
+        assert_eq!(
+            resumed_via_latest.resumed_session_id,
+            resumed.resumed_session_id,
+            "latest should point at most recently updated session"
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
     }
 
     #[test]

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -55,18 +55,28 @@ pub struct SessionState {
     pub session_id: SessionId,
     #[serde(default = "current_timestamp_ms")]
     pub created_at_ms: u64,
+    #[serde(default = "current_timestamp_ms")]
+    pub updated_at_ms: u64,
     pub messages: Vec<Prompt>,
     pub usage: UsageSummary,
 }
 
 impl Default for SessionState {
     fn default() -> Self {
+        let now = current_timestamp_ms();
         Self {
             session_id: SessionId::new(),
-            created_at_ms: current_timestamp_ms(),
+            created_at_ms: now,
+            updated_at_ms: now,
             messages: Vec::new(),
             usage: UsageSummary::default(),
         }
+    }
+}
+
+impl SessionState {
+    pub fn touch(&mut self) {
+        self.updated_at_ms = current_timestamp_ms();
     }
 }
 
@@ -74,6 +84,7 @@ impl Default for SessionState {
 pub struct SessionListing {
     pub session_id: SessionId,
     pub created_at_ms: u64,
+    pub updated_at_ms: u64,
     pub message_count: usize,
     pub persisted_path: String,
 }
@@ -144,6 +155,7 @@ impl SessionStore {
             sessions.push(SessionListing {
                 session_id: session.session_id,
                 created_at_ms: session.created_at_ms,
+                updated_at_ms: session.updated_at_ms,
                 message_count: session.messages.len(),
                 persisted_path: path.display().to_string(),
             });
@@ -151,8 +163,9 @@ impl SessionStore {
 
         sessions.sort_by(|left, right| {
             right
-                .created_at_ms
-                .cmp(&left.created_at_ms)
+                .updated_at_ms
+                .cmp(&left.updated_at_ms)
+                .then_with(|| right.created_at_ms.cmp(&left.created_at_ms))
                 .then_with(|| left.session_id.to_string().cmp(&right.session_id.to_string()))
                 .then_with(|| left.persisted_path.cmp(&right.persisted_path))
         });
@@ -184,6 +197,7 @@ mod tests {
         let session = SessionState {
             session_id: SessionId::new(),
             created_at_ms: 1_700_000_000_001,
+            updated_at_ms: 1_700_000_000_001,
             messages: vec![Prompt::new("review the runtime lane")],
             usage: harness_core::UsageSummary {
                 input_tokens: 4,
@@ -228,6 +242,7 @@ mod tests {
         let older = SessionState {
             session_id: SessionId::new(),
             created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_000_000,
             messages: vec![Prompt::new("review bash")],
             usage: harness_core::UsageSummary {
                 input_tokens: 2,
@@ -237,6 +252,7 @@ mod tests {
         let newer = SessionState {
             session_id: SessionId::new(),
             created_at_ms: 1_700_000_000_100,
+            updated_at_ms: 1_700_000_000_100,
             messages: vec![Prompt::new("summary"), Prompt::new("tools")],
             usage: harness_core::UsageSummary {
                 input_tokens: 2,
@@ -300,6 +316,7 @@ mod tests {
         let older = SessionState {
             session_id: SessionId::new(),
             created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_000_000,
             messages: vec![Prompt::new("review bash")],
             usage: harness_core::UsageSummary {
                 input_tokens: 2,
@@ -309,6 +326,7 @@ mod tests {
         let newer = SessionState {
             session_id: SessionId::new(),
             created_at_ms: 1_700_000_000_100,
+            updated_at_ms: 1_700_000_000_100,
             messages: vec![Prompt::new("summary")],
             usage: harness_core::UsageSummary {
                 input_tokens: 1,
@@ -322,6 +340,59 @@ mod tests {
         let latest = store.latest().expect("load latest session");
 
         assert_eq!(latest, newer);
+
+        fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn latest_follows_updated_at_when_older_session_is_resumed() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+        let first = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_000_000,
+            messages: vec![Prompt::new("review bash")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 2,
+                output_tokens: 2,
+            },
+        };
+        let second = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_100,
+            updated_at_ms: 1_700_000_000_100,
+            messages: vec![Prompt::new("summary")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+        };
+
+        store.save(&first).expect("save first session");
+        store.save(&second).expect("save second session");
+
+        let mut resumed_first = first.clone();
+        resumed_first.updated_at_ms = 1_700_000_000_500;
+        resumed_first.messages.push(Prompt::new("follow up"));
+        store.save(&resumed_first).expect("save resumed first session");
+
+        let latest = store.latest().expect("load latest persisted session");
+        assert_eq!(latest, resumed_first);
+
+        let listed_ids: Vec<String> = store
+            .list()
+            .expect("list persisted sessions")
+            .into_iter()
+            .map(|session| session.session_id.to_string())
+            .collect();
+        assert_eq!(
+            listed_ids,
+            vec![
+                resumed_first.session_id.to_string(),
+                second.session_id.to_string(),
+            ]
+        );
 
         fs::remove_dir_all(&root).expect("remove temp session test directory");
     }


### PR DESCRIPTION
Closes #28

## Summary
- Adds `resume <id|latest> <prompt>` CLI path that appends a new turn to an existing persisted session instead of bootstrapping a new one.
- Adds the smallest activity metadata needed for usability: `updated_at_ms` on `SessionState` / `SessionListing`; `SessionStore::list` / `latest` sort by it so `latest` follows the most recently active session (creation order is preserved as a stable tiebreaker).
- Adds a `SessionResumed` event; the resume CLI output is machine-readable JSON exposing `resumed_session_id` and `appended_turn_index` so the caller can confirm the turn targeted the intended session.

## Docs
- README: adds a `resume <id> "review summary"` section with a stable placeholder-normalized JSON fixture and notes `latest` as a supported target; extends the bootstrap / sessions / session-show blocks to include `updated_at_ms`; updates the Rust Test Coverage Baseline and Roadmap.
- ARCHITECTURE.md: documents `updated_at_ms` activity metadata, lists `resume` under `harness-cli`, adds `SessionResumed` to the event model.
- PORTING_PLAN.md: ticks the new resume CLI surface under Phase 7.

## Validation performed
- `cargo check` — clean
- `cargo test -p harness-session` — includes new `latest_follows_updated_at_when_older_session_is_resumed`
- `cargo test -p harness-runtime` — includes new `resume_appends_to_existing_session_and_emits_resume_event` and `resume_latest_targets_most_recently_active_session`
- `cargo test -p harness-cli` — includes new `resume_matches_readme_example_and_targets_existing_session` (README lock) plus updates to existing bootstrap/session-show fixtures for `updated_at_ms`
- `cargo test` — full workspace green (26 tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (also fixed a pre-existing `&PathBuf` lint in the file I touched)
- `cargo run -q -p harness-cli -- --help` — new `resume` subcommand visible

## Test plan
- [ ] CI green on push
- [ ] Reviewer spot-checks `resume latest "<prompt>"` against a session created via `bootstrap` locally to confirm the turn is appended in `.sessions/<id>.json`