### PR TITLE
feat: persist transcripts and add CLI transcript inspection (#30)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,10 +178,12 @@ Session and transcript concerns:
 - `SessionListing`
 - `TranscriptEntry`
 - `TranscriptStore`
+- `TranscriptRecord` (on-disk transcript format: `session_id`, `created_at_ms`, `updated_at_ms`, ordered `entries`)
 - `SessionStore`
 - recency metadata for persisted sessions (`created_at_ms`) plus activity metadata (`updated_at_ms`) that bumps on resume so `latest` follows the most recently active session
 - compaction policy
 - disk persistence/load/list/latest/resume-aware ordering
+- sibling transcript file per session at `<session-id>.transcript.json`, rewritten on bootstrap and resume; transcript files are excluded from session listings so session and transcript inspection stay independent
 
 ### harness-tools
 Tool concerns:
@@ -221,6 +223,7 @@ User-facing CLI:
 - `sessions` (newest-first)
 - `session show <id>`
 - `session show latest`
+- `transcript show <id>` and `transcript show latest` (machine-readable JSON transcript inspection that restates the owning session id and preserves turn ordering)
 
 ## Structured Event Model
 
@@ -239,6 +242,7 @@ The Rust runtime should expose a typed event stream. First event set:
 - `ToolCompleted`
 - `TurnCompleted`
 - `SessionPersisted`
+- `TranscriptPersisted`
 
 These should be serializable with `serde`.
 

--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -64,6 +64,7 @@ Build a Rust-native Claude Code-style CLI/runtime that Hamza can use as a primar
 - [x] `tools`
 - [x] `commands`
 - [x] `session-show <id>`
+- [x] `transcript-show <id>` (and `transcript-show latest`) — inspect the persisted transcript for an explicit session id or the most recently active session; output is machine-readable JSON that restates the owning `session_id`, the session's recency metadata, and the turn entries in `turn_index` order
 
 ## Phase 8 - Cleanup
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ cargo run -p harness-cli -- --help
 
 ## CLI Usage Examples
 
-The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses stable placeholders for generated values that vary per run: `<session-id>` for ids, `<created-at-ms>` and `<updated-at-ms>` for persisted recency/activity metadata, and matching `.sessions/<session-id>.json` paths.
+The examples below reflect the current seeded runtime surface and are protected by `cargo test -p harness-cli`. `bootstrap` creates a session file under `.sessions/`, which is gitignored, so the README uses stable placeholders for generated values that vary per run: `<session-id>` for ids, `<created-at-ms>` and `<updated-at-ms>` for persisted recency/activity metadata, and matching `.sessions/<session-id>.json` session paths plus `.sessions/<session-id>.transcript.json` transcript paths.
+
+Each persisted session now ships a sibling transcript file at `.sessions/<session-id>.transcript.json` in a deterministic format: `{ session_id, created_at_ms, updated_at_ms, entries: [{ turn_index, prompt }] }`. Entries are appended in `turn_index` order, rewritten on every bootstrap and resume, and inspectable through `transcript-show <id>` and `transcript-show latest`.
 
 ### `summary`
 
@@ -279,9 +281,15 @@ cargo run -q -p harness-cli -- bootstrap "review bash"
       "SessionPersisted": {
         "path": ".sessions/<session-id>.json"
       }
+    },
+    {
+      "TranscriptPersisted": {
+        "path": ".sessions/<session-id>.transcript.json"
+      }
     }
   ],
-  "persisted_path": ".sessions/<session-id>.json"
+  "persisted_path": ".sessions/<session-id>.json",
+  "persisted_transcript_path": ".sessions/<session-id>.transcript.json"
 }
 ```
 
@@ -382,9 +390,15 @@ cargo run -q -p harness-cli -- resume <session-id> "review summary"
       "SessionPersisted": {
         "path": ".sessions/<session-id>.json"
       }
+    },
+    {
+      "TranscriptPersisted": {
+        "path": ".sessions/<session-id>.transcript.json"
+      }
     }
   ],
-  "persisted_path": ".sessions/<session-id>.json"
+  "persisted_path": ".sessions/<session-id>.json",
+  "persisted_transcript_path": ".sessions/<session-id>.transcript.json"
 }
 ```
 
@@ -454,6 +468,50 @@ cargo run -q -p harness-cli -- session-show latest
 }
 ```
 
+### `transcript-show <id>`
+
+Inspect the persisted transcript for a specific session. The output restates the owning `session_id` and the session's recency metadata so it is self-describing, and lists turns in append order.
+
+```bash
+cargo run -q -p harness-cli -- transcript-show <session-id>
+```
+
+```json
+{
+  "session_id": "<session-id>",
+  "created_at_ms": <created-at-ms>,
+  "updated_at_ms": <updated-at-ms>,
+  "entries": [
+    {
+      "turn_index": 0,
+      "prompt": "review bash"
+    }
+  ]
+}
+```
+
+### `transcript-show latest`
+
+`latest` resolves to the transcript of the most recently active persisted session, mirroring how `session-show latest` resolves session state.
+
+```bash
+cargo run -q -p harness-cli -- transcript-show latest
+```
+
+```json
+{
+  "session_id": "<session-id>",
+  "created_at_ms": <created-at-ms>,
+  "updated_at_ms": <updated-at-ms>,
+  "entries": [
+    {
+      "turn_index": 0,
+      "prompt": "review bash"
+    }
+  ]
+}
+```
+
 ## Rust Test Coverage Baseline
 
 Current protected Rust surface:
@@ -470,6 +528,9 @@ Current protected Rust surface:
 - README-backed persisted-session example coverage for `bootstrap <prompt>`, `session-show <id>`, and `session-show latest`, with generated session identifiers normalized to `<session-id>` and generated recency metadata normalized to `<created-at-ms>` / `<updated-at-ms>` in test assertions
 - `harness-runtime` session resume behavior: an appended turn targets the original session id, bumps `updated_at_ms`, and emits a `SessionResumed` event; `resume latest` targets the most recently active session
 - README-backed CLI coverage for `resume <id> "review summary"` confirming the resumed turn is appended to the existing persisted session and the output exposes the targeted session id plus the appended turn index
+- `harness-session` transcript persistence: save/load round-trip preserves `turn_index` ordering, transcript files are excluded from session listings, and `latest_transcript` follows the most recently updated session
+- `harness-runtime` transcript persistence: `bootstrap` writes a transcript file alongside the session, emits a `TranscriptPersisted` event, and `resume` rewrites the transcript so `turn_index` ordering is extended in place
+- README-backed CLI coverage for `transcript-show <id>` and `transcript-show latest` confirming the output restates the owning `session_id` and preserves turn ordering
 
 Validation commands:
 
@@ -525,3 +586,4 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] cleanup of obsolete Python-first scaffolding
 - [x] move retained architecture-study snapshots under `archive/reference_data/`
 - [x] CLI session resume for persisted sessions (explicit id and `latest`)
+- [x] Persisted transcript files per session and CLI transcript inspection (`transcript-show <id>` and `transcript-show latest`)

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -20,6 +20,7 @@ enum CliCommand {
     Commands,
     Sessions,
     SessionShow { id: String },
+    TranscriptShow { id: String },
 }
 
 fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
@@ -55,6 +56,12 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
             let session = engine.load_session(&id).expect("load session by id");
             serde_json::to_string_pretty(&session).expect("serialize session")
         }
+        CliCommand::TranscriptShow { id } => {
+            let transcript = engine
+                .load_transcript(&id)
+                .expect("load transcript by id");
+            serde_json::to_string_pretty(&transcript).expect("serialize transcript")
+        }
     }
 }
 
@@ -70,7 +77,7 @@ mod tests {
     use super::{render_command, CliCommand};
     use harness_commands::CommandRegistry;
     use harness_runtime::RuntimeEngine;
-    use harness_session::{SessionState, SessionStore};
+    use harness_session::{SessionState, SessionStore, TranscriptRecord};
     use harness_tools::{PermissionPolicy, ToolRegistry};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -342,6 +349,94 @@ mod tests {
             reloaded_messages,
             vec!["review bash".to_string(), "review summary".to_string()],
             "resume must append to the existing persisted session"
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn transcript_show_matches_readme_example_and_confirms_session_id() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let transcript_output = render_command(
+            &engine,
+            CliCommand::TranscriptShow {
+                id: session_id.clone(),
+            },
+        );
+
+        let transcript: TranscriptRecord =
+            serde_json::from_str(&transcript_output).expect("parse transcript-show output");
+        assert_eq!(
+            transcript.session_id.to_string(),
+            session_id,
+            "transcript output must confirm the targeted session id"
+        );
+        let ordered: Vec<(usize, String)> = transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![(0, "review bash".to_string())],
+            "transcript output must preserve turn ordering"
+        );
+
+        assert_eq!(
+            normalize_session_output(&transcript_output, &session_id),
+            readme_output_block("transcript-show <id>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn transcript_show_latest_matches_readme_example() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let latest_output = render_command(
+            &engine,
+            CliCommand::TranscriptShow {
+                id: "latest".to_string(),
+            },
+        );
+
+        let latest: TranscriptRecord =
+            serde_json::from_str(&latest_output).expect("parse transcript-show latest output");
+        assert_eq!(latest.session_id.to_string(), session_id);
+
+        assert_eq!(
+            normalize_session_output(&latest_output, &session_id),
+            readme_output_block("transcript-show latest", "json")
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-core/src/lib.rs
+++ b/crates/harness-core/src/lib.rs
@@ -141,6 +141,9 @@ pub enum RuntimeEvent {
     SessionPersisted {
         path: String,
     },
+    TranscriptPersisted {
+        path: String,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -2,7 +2,9 @@ use harness_commands::{CommandRegistry, CommandResult};
 use harness_core::{
     CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName, TurnIndex,
 };
-use harness_session::{SessionListing, SessionState, SessionStore, TranscriptStore};
+use harness_session::{
+    SessionListing, SessionState, SessionStore, TranscriptRecord, TranscriptStore,
+};
 use harness_tools::{PermissionPolicy, ToolRegistry, ToolResult};
 use serde::Serialize;
 
@@ -30,6 +32,7 @@ pub struct TurnReport {
     pub tool_results: Vec<ToolResult>,
     pub events: Vec<RuntimeEvent>,
     pub persisted_path: String,
+    pub persisted_transcript_path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -44,6 +47,7 @@ pub struct ResumeReport {
     pub tool_results: Vec<ToolResult>,
     pub events: Vec<RuntimeEvent>,
     pub persisted_path: String,
+    pub persisted_transcript_path: String,
 }
 
 #[derive(Debug, Clone)]
@@ -223,6 +227,15 @@ impl RuntimeEngine {
             path: persisted_path.display().to_string(),
         });
 
+        let transcript_record = TranscriptRecord::from_session(&session, &transcript);
+        let persisted_transcript_path = self
+            .store
+            .save_transcript(&transcript_record)
+            .map_err(|err| err.to_string())?;
+        events.push(RuntimeEvent::TranscriptPersisted {
+            path: persisted_transcript_path.display().to_string(),
+        });
+
         Ok(TurnReport {
             session,
             transcript,
@@ -232,6 +245,7 @@ impl RuntimeEngine {
             tool_results,
             events,
             persisted_path: persisted_path.display().to_string(),
+            persisted_transcript_path: persisted_transcript_path.display().to_string(),
         })
     }
 
@@ -337,6 +351,15 @@ impl RuntimeEngine {
             path: persisted_path.display().to_string(),
         });
 
+        let transcript_record = TranscriptRecord::from_session(&session, &transcript);
+        let persisted_transcript_path = self
+            .store
+            .save_transcript(&transcript_record)
+            .map_err(|err| err.to_string())?;
+        events.push(RuntimeEvent::TranscriptPersisted {
+            path: persisted_transcript_path.display().to_string(),
+        });
+
         Ok(ResumeReport {
             resumed_session_id,
             appended_turn_index,
@@ -348,6 +371,7 @@ impl RuntimeEngine {
             tool_results,
             events,
             persisted_path: persisted_path.display().to_string(),
+            persisted_transcript_path: persisted_transcript_path.display().to_string(),
         })
     }
 
@@ -361,6 +385,14 @@ impl RuntimeEngine {
         }
 
         self.store.load(id).map_err(|err| err.to_string())
+    }
+
+    pub fn load_transcript(&self, id: &str) -> Result<TranscriptRecord, String> {
+        if id == "latest" {
+            return self.store.latest_transcript().map_err(|err| err.to_string());
+        }
+
+        self.store.load_transcript(id).map_err(|err| err.to_string())
     }
 }
 
@@ -498,6 +530,75 @@ mod tests {
             resumed.resumed_session_id,
             "latest should point at most recently updated session"
         );
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn bootstrap_persists_transcript_and_resume_extends_it_in_order() {
+        use harness_core::{Prompt, RuntimeEvent};
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let bootstrap = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap session");
+        let id = bootstrap.session.session_id.to_string();
+
+        assert!(bootstrap
+            .persisted_transcript_path
+            .ends_with(&format!("{id}.transcript.json")));
+        assert!(bootstrap.events.iter().any(|event| matches!(
+            event,
+            RuntimeEvent::TranscriptPersisted { path }
+                if path == &bootstrap.persisted_transcript_path
+        )));
+
+        let loaded = engine
+            .load_transcript(&id)
+            .expect("load transcript by id");
+        assert_eq!(loaded.session_id.to_string(), id);
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].prompt.0, "review bash");
+        assert_eq!(loaded.entries[0].turn_index.0, 0);
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let resumed = engine
+            .resume(&id, Prompt::new("summary please"))
+            .expect("resume session");
+        assert!(resumed
+            .persisted_transcript_path
+            .ends_with(&format!("{id}.transcript.json")));
+
+        let after_resume = engine
+            .load_transcript(&id)
+            .expect("reload transcript after resume");
+        let ordered: Vec<(usize, String)> = after_resume
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+            ]
+        );
+        assert_eq!(after_resume.session_id.to_string(), id);
+        assert_eq!(after_resume.updated_at_ms, resumed.session.updated_at_ms);
+
+        let latest = engine
+            .load_transcript("latest")
+            .expect("load latest transcript");
+        assert_eq!(latest.session_id.to_string(), id);
+        assert_eq!(latest.entries.len(), 2);
 
         fs::remove_dir_all(&root).expect("remove temp runtime test directory");
     }

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -81,6 +81,25 @@ impl SessionState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptRecord {
+    pub session_id: SessionId,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub entries: Vec<TranscriptEntry>,
+}
+
+impl TranscriptRecord {
+    pub fn from_session(session: &SessionState, transcript: &TranscriptStore) -> Self {
+        Self {
+            session_id: session.session_id.clone(),
+            created_at_ms: session.created_at_ms,
+            updated_at_ms: session.updated_at_ms,
+            entries: transcript.entries.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionListing {
     pub session_id: SessionId,
     pub created_at_ms: u64,
@@ -112,8 +131,29 @@ impl SessionStore {
         Ok(path)
     }
 
+    pub fn save_transcript(
+        &self,
+        record: &TranscriptRecord,
+    ) -> Result<PathBuf, RuntimeError> {
+        fs::create_dir_all(&self.root).map_err(|err| RuntimeError::Io(err.to_string()))?;
+        let path = self.transcript_path(&record.session_id.to_string());
+        let body = serde_json::to_string_pretty(record)
+            .map_err(|err| RuntimeError::Serialization(err.to_string()))?;
+        fs::write(&path, body).map_err(|err| RuntimeError::Io(err.to_string()))?;
+        Ok(path)
+    }
+
     pub fn load(&self, session_id: &str) -> Result<SessionState, RuntimeError> {
         let path = self.root.join(format!("{}.json", session_id));
+        if !path.exists() {
+            return Err(RuntimeError::SessionNotFound(session_id.to_string()));
+        }
+        let body = fs::read_to_string(&path).map_err(|err| RuntimeError::Io(err.to_string()))?;
+        serde_json::from_str(&body).map_err(|err| RuntimeError::Serialization(err.to_string()))
+    }
+
+    pub fn load_transcript(&self, session_id: &str) -> Result<TranscriptRecord, RuntimeError> {
+        let path = self.transcript_path(session_id);
         if !path.exists() {
             return Err(RuntimeError::SessionNotFound(session_id.to_string()));
         }
@@ -128,6 +168,19 @@ impl SessionStore {
             .next()
             .ok_or_else(|| RuntimeError::SessionNotFound("latest".to_string()))?;
         self.load(&latest.session_id.to_string())
+    }
+
+    pub fn latest_transcript(&self) -> Result<TranscriptRecord, RuntimeError> {
+        let latest = self
+            .list()?
+            .into_iter()
+            .next()
+            .ok_or_else(|| RuntimeError::SessionNotFound("latest".to_string()))?;
+        self.load_transcript(&latest.session_id.to_string())
+    }
+
+    pub fn transcript_path(&self, session_id: &str) -> PathBuf {
+        self.root.join(format!("{session_id}.transcript.json"))
     }
 
     pub fn list(&self) -> Result<Vec<SessionListing>, RuntimeError> {
@@ -145,6 +198,13 @@ impl SessionStore {
                 continue;
             }
             if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            if path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|name| name.ends_with(".transcript.json"))
+            {
                 continue;
             }
 
@@ -176,7 +236,7 @@ impl SessionStore {
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionState, SessionStore, TranscriptStore};
+    use super::{SessionState, SessionStore, TranscriptRecord, TranscriptStore};
     use harness_core::{Prompt, SessionId};
     use std::collections::BTreeMap;
     use std::fs;
@@ -340,6 +400,111 @@ mod tests {
         let latest = store.latest().expect("load latest session");
 
         assert_eq!(latest, newer);
+
+        fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn saves_and_loads_transcript_record_round_trip_preserving_order() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+        let session = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_001,
+            updated_at_ms: 1_700_000_000_050,
+            messages: vec![Prompt::new("review bash"), Prompt::new("summary please")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 4,
+                output_tokens: 4,
+            },
+        };
+
+        let mut transcript = TranscriptStore::default();
+        transcript.append(Prompt::new("review bash"));
+        transcript.append(Prompt::new("summary please"));
+
+        let record = TranscriptRecord::from_session(&session, &transcript);
+        let saved_path = store.save_transcript(&record).expect("save transcript");
+        assert_eq!(
+            saved_path,
+            root.join(format!("{}.transcript.json", session.session_id))
+        );
+
+        let loaded = store
+            .load_transcript(&session.session_id.to_string())
+            .expect("load transcript");
+
+        assert_eq!(loaded.session_id, session.session_id);
+        assert_eq!(loaded.created_at_ms, session.created_at_ms);
+        assert_eq!(loaded.updated_at_ms, session.updated_at_ms);
+        let ordered: Vec<(usize, String)> = loaded
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+            ]
+        );
+
+        store.save(&session).expect("save session state");
+        let listed_ids: Vec<String> = store
+            .list()
+            .expect("list persisted sessions")
+            .into_iter()
+            .map(|listing| listing.session_id.to_string())
+            .collect();
+        assert_eq!(listed_ids, vec![session.session_id.to_string()]);
+
+        fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn latest_transcript_follows_most_recently_updated_session() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+        let older = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_000_000,
+            messages: vec![Prompt::new("review bash")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 2,
+                output_tokens: 2,
+            },
+        };
+        let newer = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_100,
+            updated_at_ms: 1_700_000_000_100,
+            messages: vec![Prompt::new("summary")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 1,
+                output_tokens: 1,
+            },
+        };
+
+        let mut older_transcript = TranscriptStore::default();
+        older_transcript.append(Prompt::new("review bash"));
+        let mut newer_transcript = TranscriptStore::default();
+        newer_transcript.append(Prompt::new("summary"));
+
+        store.save(&older).expect("save older session");
+        store.save(&newer).expect("save newer session");
+        store
+            .save_transcript(&TranscriptRecord::from_session(&older, &older_transcript))
+            .expect("save older transcript");
+        store
+            .save_transcript(&TranscriptRecord::from_session(&newer, &newer_transcript))
+            .expect("save newer transcript");
+
+        let latest = store.latest_transcript().expect("load latest transcript");
+        assert_eq!(latest.session_id, newer.session_id);
+        assert_eq!(latest.entries.len(), 1);
+        assert_eq!(latest.entries[0].prompt.0, "summary");
 
         fs::remove_dir_all(&root).expect("remove temp session test directory");
     }


### PR DESCRIPTION
Closes #30.

## Summary
- Persist a sibling transcript file per session at `.sessions/<session-id>.transcript.json` in a deterministic shape: `{ session_id, created_at_ms, updated_at_ms, entries: [{ turn_index, prompt }] }`. The record restates the owning session id, preserves turn ordering, and is rewritten on every bootstrap and resume.
- Add a new runtime event `TranscriptPersisted` and surface the on-disk transcript path on `TurnReport` / `ResumeReport` as `persisted_transcript_path`.
- Add a user-facing CLI path `transcript-show <id>` with `latest` support, returning machine-readable JSON that confirms the transcript belongs to the intended session and preserves turn ordering.
- Session listing still skips transcript files, so existing `bootstrap`, `resume`, `sessions`, and `session-show` behavior stays stable (only additive documented fields).
- Update `README.md`, `ARCHITECTURE.md`, and `PORTING_PLAN.md` so the documented persisted-session workflow matches repo truth, including the new `TranscriptPersisted` event and the two `transcript-show` examples.

## Test plan
- [x] `cargo test -p harness-session` — transcript round-trip preserves `turn_index` ordering; transcript files excluded from session listings; `latest_transcript` follows the most recently updated session
- [x] `cargo test -p harness-runtime` — `bootstrap` writes a transcript and emits `TranscriptPersisted`; `resume` extends the transcript in order; `latest` resolves to the most recently active transcript
- [x] `cargo test -p harness-cli` — README-backed coverage for `transcript-show <id>` and `transcript-show latest`; existing `bootstrap` / `resume` README examples updated to include the new event and `persisted_transcript_path` field
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -q -p harness-cli -- --help` confirms `transcript-show` is registered