### PR TITLE
feat: add CLI session-export for persisted session bundles (#32)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,6 +179,7 @@ Session and transcript concerns:
 - `TranscriptEntry`
 - `TranscriptStore`
 - `TranscriptRecord` (on-disk transcript format: `session_id`, `created_at_ms`, `updated_at_ms`, ordered `entries`)
+- `SessionExport` (deterministic export bundle: `exported_session_id`, `session`, `transcript`; bundles session state with its transcript for archival, sharing, or debugging)
 - `SessionStore`
 - recency metadata for persisted sessions (`created_at_ms`) plus activity metadata (`updated_at_ms`) that bumps on resume so `latest` follows the most recently active session
 - compaction policy
@@ -224,6 +225,7 @@ User-facing CLI:
 - `session show <id>`
 - `session show latest`
 - `transcript show <id>` and `transcript show latest` (machine-readable JSON transcript inspection that restates the owning session id and preserves turn ordering)
+- `session-export <id>` and `session-export latest` (deterministic JSON export bundle that packages session state plus transcript together; output confirms the exported session id and preserves turn ordering)
 
 ## Structured Event Model
 

--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -65,6 +65,7 @@ Build a Rust-native Claude Code-style CLI/runtime that Hamza can use as a primar
 - [x] `commands`
 - [x] `session-show <id>`
 - [x] `transcript-show <id>` (and `transcript-show latest`) — inspect the persisted transcript for an explicit session id or the most recently active session; output is machine-readable JSON that restates the owning `session_id`, the session's recency metadata, and the turn entries in `turn_index` order
+- [x] `session-export <id>` (and `session-export latest`) — export a persisted session bundle as deterministic JSON packaging session state plus transcript together; output confirms the `exported_session_id` and preserves `turn_index` ordering so bundles can be archived, attached to bug reports, or compared across environments without manually inspecting `.sessions/` files
 
 ## Phase 8 - Cleanup
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The first meaningful milestone is:
 - tool and command registries
 - deterministic routing
 - runtime turn processor with structured events
-- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, and session inspection
+- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, session inspection, transcript inspection, and session export
 
 See:
 
@@ -512,6 +512,80 @@ cargo run -q -p harness-cli -- transcript-show latest
 }
 ```
 
+### `session-export <id>`
+
+Export one persisted session as a single machine-readable JSON bundle that packages the session state and its transcript together. The output uses a deterministic shape: `{ exported_session_id, session, transcript }`, where `session` is the same structure printed by `session-show` and `transcript` is the same structure printed by `transcript-show`. The `exported_session_id` confirms which session was exported and always equals the `session_id` inside both nested records. Turn ordering in `transcript.entries` is preserved in `turn_index` order so the bundle is safe to attach to bug reports or archive outside the repo-local `.sessions/` layout.
+
+```bash
+cargo run -q -p harness-cli -- session-export <session-id>
+```
+
+```json
+{
+  "exported_session_id": "<session-id>",
+  "session": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "messages": [
+      "review bash"
+    ],
+    "usage": {
+      "input_tokens": 2,
+      "output_tokens": 2
+    }
+  },
+  "transcript": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "entries": [
+      {
+        "turn_index": 0,
+        "prompt": "review bash"
+      }
+    ]
+  }
+}
+```
+
+### `session-export latest`
+
+`latest` resolves to the most recently active persisted session, mirroring how `session-show latest` and `transcript-show latest` resolve their targets.
+
+```bash
+cargo run -q -p harness-cli -- session-export latest
+```
+
+```json
+{
+  "exported_session_id": "<session-id>",
+  "session": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "messages": [
+      "review bash"
+    ],
+    "usage": {
+      "input_tokens": 2,
+      "output_tokens": 2
+    }
+  },
+  "transcript": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "entries": [
+      {
+        "turn_index": 0,
+        "prompt": "review bash"
+      }
+    ]
+  }
+}
+```
+
 ## Rust Test Coverage Baseline
 
 Current protected Rust surface:
@@ -531,6 +605,9 @@ Current protected Rust surface:
 - `harness-session` transcript persistence: save/load round-trip preserves `turn_index` ordering, transcript files are excluded from session listings, and `latest_transcript` follows the most recently updated session
 - `harness-runtime` transcript persistence: `bootstrap` writes a transcript file alongside the session, emits a `TranscriptPersisted` event, and `resume` rewrites the transcript so `turn_index` ordering is extended in place
 - README-backed CLI coverage for `transcript-show <id>` and `transcript-show latest` confirming the output restates the owning `session_id` and preserves turn ordering
+- `harness-session` `SessionExport` bundle round-trip: packages session state plus transcript, confirms the exported session id, and preserves `turn_index` ordering in the exported transcript with deterministic serialization
+- `harness-runtime` `export_session` behavior: bundles the persisted session and its transcript for an explicit id, and `latest` resolves to the same bundle
+- README-backed CLI coverage for `session-export <id>` and `session-export latest` confirming the output exposes the `exported_session_id` and preserves turn ordering
 
 Validation commands:
 
@@ -587,3 +664,4 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] move retained architecture-study snapshots under `archive/reference_data/`
 - [x] CLI session resume for persisted sessions (explicit id and `latest`)
 - [x] Persisted transcript files per session and CLI transcript inspection (`transcript-show <id>` and `transcript-show latest`)
+- [x] CLI session export for persisted session bundles (`session-export <id>` and `session-export latest`) in a deterministic JSON shape packaging session state plus transcript

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -21,6 +21,7 @@ enum CliCommand {
     Sessions,
     SessionShow { id: String },
     TranscriptShow { id: String },
+    SessionExport { id: String },
 }
 
 fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
@@ -62,6 +63,10 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
                 .expect("load transcript by id");
             serde_json::to_string_pretty(&transcript).expect("serialize transcript")
         }
+        CliCommand::SessionExport { id } => {
+            let export = engine.export_session(&id).expect("export persisted session");
+            serde_json::to_string_pretty(&export).expect("serialize session export")
+        }
     }
 }
 
@@ -77,7 +82,7 @@ mod tests {
     use super::{render_command, CliCommand};
     use harness_commands::CommandRegistry;
     use harness_runtime::RuntimeEngine;
-    use harness_session::{SessionState, SessionStore, TranscriptRecord};
+    use harness_session::{SessionExport, SessionState, SessionStore, TranscriptRecord};
     use harness_tools::{PermissionPolicy, ToolRegistry};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -437,6 +442,105 @@ mod tests {
         assert_eq!(
             normalize_session_output(&latest_output, &session_id),
             readme_output_block("transcript-show latest", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_export_matches_readme_example_and_confirms_session_id() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let export_output = render_command(
+            &engine,
+            CliCommand::SessionExport {
+                id: session_id.clone(),
+            },
+        );
+
+        let export: SessionExport =
+            serde_json::from_str(&export_output).expect("parse session-export output");
+        assert_eq!(
+            export.exported_session_id.to_string(),
+            session_id,
+            "export output must confirm the targeted session id"
+        );
+        assert_eq!(
+            export.session.session_id.to_string(),
+            session_id,
+            "nested session id must match the exported id"
+        );
+        assert_eq!(
+            export.transcript.session_id.to_string(),
+            session_id,
+            "nested transcript session id must match the exported id"
+        );
+        let ordered: Vec<(usize, String)> = export
+            .transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![(0, "review bash".to_string())],
+            "exported transcript must preserve turn ordering"
+        );
+
+        assert_eq!(
+            normalize_session_output(&export_output, &session_id),
+            readme_output_block("session-export <id>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_export_latest_matches_readme_example() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let latest_output = render_command(
+            &engine,
+            CliCommand::SessionExport {
+                id: "latest".to_string(),
+            },
+        );
+
+        let latest: SessionExport =
+            serde_json::from_str(&latest_output).expect("parse session-export latest output");
+        assert_eq!(latest.exported_session_id.to_string(), session_id);
+
+        assert_eq!(
+            normalize_session_output(&latest_output, &session_id),
+            readme_output_block("session-export latest", "json")
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -3,7 +3,7 @@ use harness_core::{
     CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName, TurnIndex,
 };
 use harness_session::{
-    SessionListing, SessionState, SessionStore, TranscriptRecord, TranscriptStore,
+    SessionExport, SessionListing, SessionState, SessionStore, TranscriptRecord, TranscriptStore,
 };
 use harness_tools::{PermissionPolicy, ToolRegistry, ToolResult};
 use serde::Serialize;
@@ -394,6 +394,15 @@ impl RuntimeEngine {
 
         self.store.load_transcript(id).map_err(|err| err.to_string())
     }
+
+    pub fn export_session(&self, id: &str) -> Result<SessionExport, String> {
+        let session = self.load_session(id)?;
+        let transcript = self
+            .store
+            .load_transcript(&session.session_id.to_string())
+            .map_err(|err| err.to_string())?;
+        Ok(SessionExport::new(session, transcript))
+    }
 }
 
 #[cfg(test)]
@@ -599,6 +608,52 @@ mod tests {
             .expect("load latest transcript");
         assert_eq!(latest.session_id.to_string(), id);
         assert_eq!(latest.entries.len(), 2);
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn export_session_bundles_persisted_state_and_transcript_for_id_and_latest() {
+        use harness_core::Prompt;
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let bootstrap = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap session");
+        let id = bootstrap.session.session_id.to_string();
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let resumed = engine
+            .resume(&id, Prompt::new("summary please"))
+            .expect("resume session");
+
+        let export = engine.export_session(&id).expect("export by id");
+        assert_eq!(export.exported_session_id.to_string(), id);
+        assert_eq!(export.session, resumed.session);
+        assert_eq!(export.transcript.session_id.to_string(), id);
+        let ordered: Vec<(usize, String)> = export
+            .transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+            ]
+        );
+
+        let latest_export = engine.export_session("latest").expect("export latest");
+        assert_eq!(latest_export, export, "`latest` must resolve to the same bundle");
 
         fs::remove_dir_all(&root).expect("remove temp runtime test directory");
     }

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -100,6 +100,23 @@ impl TranscriptRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionExport {
+    pub exported_session_id: SessionId,
+    pub session: SessionState,
+    pub transcript: TranscriptRecord,
+}
+
+impl SessionExport {
+    pub fn new(session: SessionState, transcript: TranscriptRecord) -> Self {
+        Self {
+            exported_session_id: session.session_id.clone(),
+            session,
+            transcript,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionListing {
     pub session_id: SessionId,
     pub created_at_ms: u64,
@@ -236,7 +253,7 @@ impl SessionStore {
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionState, SessionStore, TranscriptRecord, TranscriptStore};
+    use super::{SessionExport, SessionState, SessionStore, TranscriptRecord, TranscriptStore};
     use harness_core::{Prompt, SessionId};
     use std::collections::BTreeMap;
     use std::fs;
@@ -507,6 +524,54 @@ mod tests {
         assert_eq!(latest.entries[0].prompt.0, "summary");
 
         fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn session_export_bundles_session_and_transcript_and_confirms_id() {
+        let session = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_001,
+            updated_at_ms: 1_700_000_000_050,
+            messages: vec![Prompt::new("review bash"), Prompt::new("summary please")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 4,
+                output_tokens: 4,
+            },
+        };
+
+        let mut transcript = TranscriptStore::default();
+        transcript.append(Prompt::new("review bash"));
+        transcript.append(Prompt::new("summary please"));
+        let record = TranscriptRecord::from_session(&session, &transcript);
+
+        let export = SessionExport::new(session.clone(), record.clone());
+
+        assert_eq!(export.exported_session_id, session.session_id);
+        assert_eq!(export.session, session);
+        assert_eq!(export.transcript, record);
+
+        let serialized = serde_json::to_string(&export).expect("serialize export");
+        let ordered: Vec<(usize, String)> = export
+            .transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+            ],
+            "export transcript must preserve turn ordering"
+        );
+
+        let again = serde_json::to_string(&export).expect("serialize export again");
+        assert_eq!(serialized, again, "export serialization should be deterministic");
+
+        let roundtrip: SessionExport =
+            serde_json::from_str(&serialized).expect("deserialize export");
+        assert_eq!(roundtrip, export);
     }
 
     #[test]


### PR DESCRIPTION
Closes #32.

## Summary
- Adds a new user-facing CLI path `session-export <id>` with `latest` supported as an ergonomic target for the most recently active persisted session.
- Exports a deterministic JSON bundle with shape `{ exported_session_id, session, transcript }`:
  - `session` matches the `session-show` output,
  - `transcript` matches the `transcript-show` output,
  - `exported_session_id` confirms which session was exported and always equals the `session_id` inside both nested records.
- Preserves `turn_index` ordering in the exported transcript so bundles are safe to attach to bug reports or archive outside `.sessions/`.
- Keeps `bootstrap`, `resume`, `sessions`, `session-show`, and `transcript-show` behavior unchanged.

## Changes
- `harness-session`: new `SessionExport { exported_session_id, session, transcript }` type with `SessionExport::new`.
- `harness-runtime`: new `RuntimeEngine::export_session(id)` that supports explicit ids and `latest`.
- `harness-cli`: new `session-export <id>` subcommand.
- Docs: README gains `session-export <id>` and `session-export latest` examples (a protected regression surface), plus updates to ARCHITECTURE.md, PORTING_PLAN.md, and roadmap/coverage notes.

## Test plan
- [x] `cargo test -p harness-session` (new `session_export_bundles_session_and_transcript_and_confirms_id` + existing)
- [x] `cargo test -p harness-runtime` (new `export_session_bundles_persisted_state_and_transcript_for_id_and_latest` + existing)
- [x] `cargo test -p harness-cli` (new README-backed `session_export_matches_readme_example_and_confirms_session_id` and `session_export_latest_matches_readme_example` + existing)
- [x] `cargo test` (all 35 tests pass across the workspace)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean