### PR TITLE
feat: add CLI session-compare for persisted sessions (#34)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,7 @@ Session and transcript concerns:
 - `TranscriptStore`
 - `TranscriptRecord` (on-disk transcript format: `session_id`, `created_at_ms`, `updated_at_ms`, ordered `entries`)
 - `SessionExport` (deterministic export bundle: `exported_session_id`, `session`, `transcript`; bundles session state with its transcript for archival, sharing, or debugging)
+- `SessionComparison` (deterministic comparison bundle: `left_session_id`, `right_session_id`, `left`, `right`, `differences`; `differences` carries a `same_session` flag plus signed `created_at_ms_delta`, `updated_at_ms_delta`, `message_count_delta`, and `transcript_entry_count_delta` computed as `right - left` so the direction of the comparison is preserved)
 - `SessionStore`
 - recency metadata for persisted sessions (`created_at_ms`) plus activity metadata (`updated_at_ms`) that bumps on resume so `latest` follows the most recently active session
 - compaction policy
@@ -226,6 +227,7 @@ User-facing CLI:
 - `session show latest`
 - `transcript show <id>` and `transcript show latest` (machine-readable JSON transcript inspection that restates the owning session id and preserves turn ordering)
 - `session-export <id>` and `session-export latest` (deterministic JSON export bundle that packages session state plus transcript together; output confirms the exported session id and preserves turn ordering)
+- `session-compare <left-id> <right-id>` with `latest` accepted on either side (deterministic JSON comparison bundle that identifies both compared session ids and reports signed deltas for recency/activity metadata and transcript/turn counts)
 
 ## Structured Event Model
 

--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -66,6 +66,7 @@ Build a Rust-native Claude Code-style CLI/runtime that Hamza can use as a primar
 - [x] `session-show <id>`
 - [x] `transcript-show <id>` (and `transcript-show latest`) — inspect the persisted transcript for an explicit session id or the most recently active session; output is machine-readable JSON that restates the owning `session_id`, the session's recency metadata, and the turn entries in `turn_index` order
 - [x] `session-export <id>` (and `session-export latest`) — export a persisted session bundle as deterministic JSON packaging session state plus transcript together; output confirms the `exported_session_id` and preserves `turn_index` ordering so bundles can be archived, attached to bug reports, or compared across environments without manually inspecting `.sessions/` files
+- [x] `session-compare <left-id> <right-id>` (with `latest` accepted on either side) — compare two persisted sessions as a single machine-readable JSON bundle that identifies both compared `session_id`s and reports signed `right - left` deltas for recency metadata (`created_at_ms_delta`, `updated_at_ms_delta`) and activity metadata (`message_count_delta`, `transcript_entry_count_delta`), plus a `same_session` flag so self-comparisons via `latest latest` are trivially recognizable
 
 ## Phase 8 - Cleanup
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The first meaningful milestone is:
 - tool and command registries
 - deterministic routing
 - runtime turn processor with structured events
-- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, session inspection, transcript inspection, and session export
+- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, session inspection, transcript inspection, session export, and session comparison
 
 See:
 
@@ -586,6 +586,78 @@ cargo run -q -p harness-cli -- session-export latest
 }
 ```
 
+### `session-compare <left-id> <right-id>`
+
+Compare two persisted sessions side-by-side as a single machine-readable JSON bundle. The output uses a deterministic shape: `{ left_session_id, right_session_id, left, right, differences }`. Both `left` and `right` carry the compared session's `session_id`, recency metadata (`created_at_ms`, `updated_at_ms`), and activity metadata (`message_count`, `transcript_entry_count`). `differences` reports signed deltas computed as `right - left` so the comparison direction is preserved, plus a `same_session` flag that is `true` when both sides resolve to the same persisted session. Either side accepts the literal `latest` selector, mirroring how `session-show latest`, `transcript-show latest`, and `session-export latest` resolve the most recently active persisted session.
+
+```bash
+cargo run -q -p harness-cli -- session-compare <left-session-id> <right-session-id>
+```
+
+```json
+{
+  "left_session_id": "<left-session-id>",
+  "right_session_id": "<right-session-id>",
+  "left": {
+    "session_id": "<left-session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "message_count": 1,
+    "transcript_entry_count": 1
+  },
+  "right": {
+    "session_id": "<right-session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "message_count": 1,
+    "transcript_entry_count": 1
+  },
+  "differences": {
+    "same_session": false,
+    "created_at_ms_delta": <created-at-ms-delta>,
+    "updated_at_ms_delta": <updated-at-ms-delta>,
+    "message_count_delta": 0,
+    "transcript_entry_count_delta": 0
+  }
+}
+```
+
+### `session-compare latest latest`
+
+Resolving both sides to `latest` yields a deterministic self-comparison where `same_session` is `true` and every delta is `0`. This is the smallest way to confirm the comparison path is healthy without needing two distinct persisted sessions in hand.
+
+```bash
+cargo run -q -p harness-cli -- session-compare latest latest
+```
+
+```json
+{
+  "left_session_id": "<session-id>",
+  "right_session_id": "<session-id>",
+  "left": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "message_count": 1,
+    "transcript_entry_count": 1
+  },
+  "right": {
+    "session_id": "<session-id>",
+    "created_at_ms": <created-at-ms>,
+    "updated_at_ms": <updated-at-ms>,
+    "message_count": 1,
+    "transcript_entry_count": 1
+  },
+  "differences": {
+    "same_session": true,
+    "created_at_ms_delta": 0,
+    "updated_at_ms_delta": 0,
+    "message_count_delta": 0,
+    "transcript_entry_count_delta": 0
+  }
+}
+```
+
 ## Rust Test Coverage Baseline
 
 Current protected Rust surface:
@@ -608,6 +680,9 @@ Current protected Rust surface:
 - `harness-session` `SessionExport` bundle round-trip: packages session state plus transcript, confirms the exported session id, and preserves `turn_index` ordering in the exported transcript with deterministic serialization
 - `harness-runtime` `export_session` behavior: bundles the persisted session and its transcript for an explicit id, and `latest` resolves to the same bundle
 - README-backed CLI coverage for `session-export <id>` and `session-export latest` confirming the output exposes the `exported_session_id` and preserves turn ordering
+- `harness-session` `SessionComparison` bundle: pairs two sides with shared recency/activity metadata, reports signed `right - left` deltas (including negative deltas when order is reversed), exposes a `same_session` flag, and serializes deterministically
+- `harness-runtime` `compare_sessions` behavior: resolves explicit ids and the `latest` selector on either side, computes deltas against persisted session state plus transcripts, and treats a self-comparison as `same_session: true` with zero deltas
+- README-backed CLI coverage for `session-compare <left-id> <right-id>` and `session-compare latest latest` confirming the output identifies both compared session ids and that a `latest latest` self-comparison reports `same_session: true` with every delta equal to `0`
 
 Validation commands:
 
@@ -665,3 +740,4 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] CLI session resume for persisted sessions (explicit id and `latest`)
 - [x] Persisted transcript files per session and CLI transcript inspection (`transcript-show <id>` and `transcript-show latest`)
 - [x] CLI session export for persisted session bundles (`session-export <id>` and `session-export latest`) in a deterministic JSON shape packaging session state plus transcript
+- [x] CLI session comparison for persisted sessions (`session-compare <left-id> <right-id>` with `latest` accepted on either side) in a deterministic JSON shape that identifies both compared session ids and reports signed deltas for recency metadata and transcript/turn counts

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -22,6 +22,7 @@ enum CliCommand {
     SessionShow { id: String },
     TranscriptShow { id: String },
     SessionExport { id: String },
+    SessionCompare { left: String, right: String },
 }
 
 fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
@@ -67,6 +68,12 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
             let export = engine.export_session(&id).expect("export persisted session");
             serde_json::to_string_pretty(&export).expect("serialize session export")
         }
+        CliCommand::SessionCompare { left, right } => {
+            let comparison = engine
+                .compare_sessions(&left, &right)
+                .expect("compare persisted sessions");
+            serde_json::to_string_pretty(&comparison).expect("serialize session comparison")
+        }
     }
 }
 
@@ -82,7 +89,9 @@ mod tests {
     use super::{render_command, CliCommand};
     use harness_commands::CommandRegistry;
     use harness_runtime::RuntimeEngine;
-    use harness_session::{SessionExport, SessionState, SessionStore, TranscriptRecord};
+    use harness_session::{
+        SessionComparison, SessionExport, SessionState, SessionStore, TranscriptRecord,
+    };
     use harness_tools::{PermissionPolicy, ToolRegistry};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -149,6 +158,51 @@ mod tests {
         }
         normalized.push_str(remaining);
         normalized
+    }
+
+    fn normalize_signed_number_field(output: &str, field: &str, placeholder: &str) -> String {
+        let marker = format!("\"{field}\": ");
+        let mut remaining = output;
+        let mut normalized = String::with_capacity(output.len());
+        while let Some(start) = remaining.find(&marker) {
+            let value_start = start + marker.len();
+            let scan_start = if remaining[value_start..].starts_with('-') {
+                value_start + 1
+            } else {
+                value_start
+            };
+            let value_end = remaining[scan_start..]
+                .find(|ch: char| !ch.is_ascii_digit())
+                .map(|offset| scan_start + offset)
+                .unwrap_or(remaining.len());
+
+            normalized.push_str(&remaining[..value_start]);
+            normalized.push_str(placeholder);
+            remaining = &remaining[value_end..];
+        }
+        normalized.push_str(remaining);
+        normalized
+    }
+
+    fn normalize_comparison_output(
+        output: &str,
+        left_session_id: &str,
+        right_session_id: &str,
+    ) -> String {
+        let replaced = output
+            .replace(left_session_id, "<left-session-id>")
+            .replace(right_session_id, "<right-session-id>");
+        let timestamps = normalize_timestamps(&replaced);
+        let with_created_delta = normalize_signed_number_field(
+            &timestamps,
+            "created_at_ms_delta",
+            "<created-at-ms-delta>",
+        );
+        normalize_signed_number_field(
+            &with_created_delta,
+            "updated_at_ms_delta",
+            "<updated-at-ms-delta>",
+        )
     }
 
     fn normalize_timestamps(output: &str) -> String {
@@ -541,6 +595,115 @@ mod tests {
         assert_eq!(
             normalize_session_output(&latest_output, &session_id),
             readme_output_block("session-export latest", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_compare_matches_readme_example_and_identifies_both_sessions() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let left_bootstrap = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let left_json: serde_json::Value =
+            serde_json::from_str(&left_bootstrap).expect("parse left bootstrap report");
+        let left_id = left_json["session"]["session_id"]
+            .as_str()
+            .expect("left session id")
+            .to_string();
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let right_bootstrap = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "summary please".to_string(),
+            },
+        );
+        let right_json: serde_json::Value =
+            serde_json::from_str(&right_bootstrap).expect("parse right bootstrap report");
+        let right_id = right_json["session"]["session_id"]
+            .as_str()
+            .expect("right session id")
+            .to_string();
+
+        let compare_output = render_command(
+            &engine,
+            CliCommand::SessionCompare {
+                left: left_id.clone(),
+                right: right_id.clone(),
+            },
+        );
+
+        let comparison: SessionComparison =
+            serde_json::from_str(&compare_output).expect("parse session-compare output");
+        assert_eq!(
+            comparison.left_session_id.to_string(),
+            left_id,
+            "left_session_id must match the requested left target"
+        );
+        assert_eq!(
+            comparison.right_session_id.to_string(),
+            right_id,
+            "right_session_id must match the requested right target"
+        );
+        assert!(!comparison.differences.same_session);
+        assert_eq!(comparison.differences.message_count_delta, 0);
+        assert_eq!(comparison.differences.transcript_entry_count_delta, 0);
+
+        assert_eq!(
+            normalize_comparison_output(&compare_output, &left_id, &right_id),
+            readme_output_block("session-compare <left-id> <right-id>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_compare_latest_latest_matches_readme_example_and_is_self_comparison() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let session_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let compare_output = render_command(
+            &engine,
+            CliCommand::SessionCompare {
+                left: "latest".to_string(),
+                right: "latest".to_string(),
+            },
+        );
+
+        let comparison: SessionComparison =
+            serde_json::from_str(&compare_output).expect("parse session-compare latest output");
+        assert_eq!(comparison.left_session_id.to_string(), session_id);
+        assert_eq!(comparison.right_session_id.to_string(), session_id);
+        assert!(comparison.differences.same_session);
+        assert_eq!(comparison.differences.created_at_ms_delta, 0);
+        assert_eq!(comparison.differences.updated_at_ms_delta, 0);
+        assert_eq!(comparison.differences.message_count_delta, 0);
+        assert_eq!(comparison.differences.transcript_entry_count_delta, 0);
+
+        assert_eq!(
+            normalize_session_output(&compare_output, &session_id),
+            readme_output_block("session-compare latest latest", "json")
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -3,7 +3,8 @@ use harness_core::{
     CommandName, MatchScore, PermissionDenial, Prompt, RuntimeEvent, SessionId, ToolName, TurnIndex,
 };
 use harness_session::{
-    SessionExport, SessionListing, SessionState, SessionStore, TranscriptRecord, TranscriptStore,
+    SessionComparison, SessionComparisonSide, SessionExport, SessionListing, SessionState,
+    SessionStore, TranscriptRecord, TranscriptStore,
 };
 use harness_tools::{PermissionPolicy, ToolRegistry, ToolResult};
 use serde::Serialize;
@@ -403,6 +404,22 @@ impl RuntimeEngine {
             .map_err(|err| err.to_string())?;
         Ok(SessionExport::new(session, transcript))
     }
+
+    pub fn compare_sessions(&self, left: &str, right: &str) -> Result<SessionComparison, String> {
+        Ok(SessionComparison::new(
+            self.comparison_side_for(left)?,
+            self.comparison_side_for(right)?,
+        ))
+    }
+
+    fn comparison_side_for(&self, id: &str) -> Result<SessionComparisonSide, String> {
+        let session = self.load_session(id)?;
+        let transcript = self
+            .store
+            .load_transcript(&session.session_id.to_string())
+            .map_err(|err| err.to_string())?;
+        Ok(SessionComparisonSide::from_parts(&session, &transcript))
+    }
 }
 
 #[cfg(test)]
@@ -654,6 +671,79 @@ mod tests {
 
         let latest_export = engine.export_session("latest").expect("export latest");
         assert_eq!(latest_export, export, "`latest` must resolve to the same bundle");
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn compare_sessions_reports_signed_deltas_between_persisted_sessions_and_supports_latest() {
+        use harness_core::Prompt;
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let first = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap first session");
+        let first_id = first.session.session_id.to_string();
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let second = engine
+            .bootstrap(Prompt::new("summary"))
+            .expect("bootstrap second session");
+        let second_id = second.session.session_id.to_string();
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let resumed_second = engine
+            .resume(&second_id, Prompt::new("follow up"))
+            .expect("resume second session");
+
+        let comparison = engine
+            .compare_sessions(&first_id, &second_id)
+            .expect("compare two persisted sessions");
+
+        assert_eq!(comparison.left_session_id.to_string(), first_id);
+        assert_eq!(comparison.right_session_id.to_string(), second_id);
+        assert_eq!(comparison.left.message_count, 1);
+        assert_eq!(comparison.right.message_count, 2);
+        assert_eq!(comparison.left.transcript_entry_count, 1);
+        assert_eq!(comparison.right.transcript_entry_count, 2);
+        assert!(!comparison.differences.same_session);
+        assert_eq!(comparison.differences.message_count_delta, 1);
+        assert_eq!(comparison.differences.transcript_entry_count_delta, 1);
+        assert!(comparison.differences.updated_at_ms_delta >= 0);
+        assert_eq!(
+            comparison.right.updated_at_ms,
+            resumed_second.session.updated_at_ms
+        );
+
+        let latest_right = engine
+            .compare_sessions(&first_id, "latest")
+            .expect("compare with latest on right side");
+        assert_eq!(latest_right.right_session_id.to_string(), second_id);
+        assert_eq!(latest_right, comparison);
+
+        let latest_left = engine
+            .compare_sessions("latest", &first_id)
+            .expect("compare with latest on left side");
+        assert_eq!(latest_left.left_session_id.to_string(), second_id);
+        assert_eq!(latest_left.right_session_id.to_string(), first_id);
+        assert_eq!(
+            latest_left.differences.message_count_delta,
+            -comparison.differences.message_count_delta
+        );
+
+        let self_compare = engine
+            .compare_sessions(&first_id, &first_id)
+            .expect("compare session with itself");
+        assert!(self_compare.differences.same_session);
+        assert_eq!(self_compare.differences.message_count_delta, 0);
+        assert_eq!(self_compare.differences.updated_at_ms_delta, 0);
 
         fs::remove_dir_all(&root).expect("remove temp runtime test directory");
     }

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -117,6 +117,81 @@ impl SessionExport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionComparisonSide {
+    pub session_id: SessionId,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub message_count: usize,
+    pub transcript_entry_count: usize,
+}
+
+impl SessionComparisonSide {
+    pub fn from_parts(session: &SessionState, transcript: &TranscriptRecord) -> Self {
+        Self {
+            session_id: session.session_id.clone(),
+            created_at_ms: session.created_at_ms,
+            updated_at_ms: session.updated_at_ms,
+            message_count: session.messages.len(),
+            transcript_entry_count: transcript.entries.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionComparisonDifferences {
+    pub same_session: bool,
+    pub created_at_ms_delta: i64,
+    pub updated_at_ms_delta: i64,
+    pub message_count_delta: i64,
+    pub transcript_entry_count_delta: i64,
+}
+
+impl SessionComparisonDifferences {
+    pub fn between(left: &SessionComparisonSide, right: &SessionComparisonSide) -> Self {
+        Self {
+            same_session: left.session_id == right.session_id,
+            created_at_ms_delta: signed_delta(left.created_at_ms, right.created_at_ms),
+            updated_at_ms_delta: signed_delta(left.updated_at_ms, right.updated_at_ms),
+            message_count_delta: signed_usize_delta(left.message_count, right.message_count),
+            transcript_entry_count_delta: signed_usize_delta(
+                left.transcript_entry_count,
+                right.transcript_entry_count,
+            ),
+        }
+    }
+}
+
+fn signed_delta(left: u64, right: u64) -> i64 {
+    (right as i128 - left as i128) as i64
+}
+
+fn signed_usize_delta(left: usize, right: usize) -> i64 {
+    (right as i128 - left as i128) as i64
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionComparison {
+    pub left_session_id: SessionId,
+    pub right_session_id: SessionId,
+    pub left: SessionComparisonSide,
+    pub right: SessionComparisonSide,
+    pub differences: SessionComparisonDifferences,
+}
+
+impl SessionComparison {
+    pub fn new(left: SessionComparisonSide, right: SessionComparisonSide) -> Self {
+        let differences = SessionComparisonDifferences::between(&left, &right);
+        Self {
+            left_session_id: left.session_id.clone(),
+            right_session_id: right.session_id.clone(),
+            left,
+            right,
+            differences,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionListing {
     pub session_id: SessionId,
     pub created_at_ms: u64,
@@ -253,7 +328,10 @@ impl SessionStore {
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionExport, SessionState, SessionStore, TranscriptRecord, TranscriptStore};
+    use super::{
+        SessionComparison, SessionComparisonSide, SessionExport, SessionState, SessionStore,
+        TranscriptRecord, TranscriptStore,
+    };
     use harness_core::{Prompt, SessionId};
     use std::collections::BTreeMap;
     use std::fs;
@@ -572,6 +650,78 @@ mod tests {
         let roundtrip: SessionExport =
             serde_json::from_str(&serialized).expect("deserialize export");
         assert_eq!(roundtrip, export);
+    }
+
+    #[test]
+    fn session_comparison_reports_signed_deltas_and_same_session_flag() {
+        let left_state = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_000_100,
+            messages: vec![Prompt::new("review bash")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 2,
+                output_tokens: 2,
+            },
+        };
+        let right_state = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_050,
+            updated_at_ms: 1_700_000_000_500,
+            messages: vec![
+                Prompt::new("review bash"),
+                Prompt::new("summary please"),
+                Prompt::new("one more"),
+            ],
+            usage: harness_core::UsageSummary {
+                input_tokens: 6,
+                output_tokens: 6,
+            },
+        };
+
+        let mut left_transcript = TranscriptStore::default();
+        left_transcript.append(Prompt::new("review bash"));
+        let mut right_transcript = TranscriptStore::default();
+        right_transcript.append(Prompt::new("review bash"));
+        right_transcript.append(Prompt::new("summary please"));
+        right_transcript.append(Prompt::new("one more"));
+
+        let left_record = TranscriptRecord::from_session(&left_state, &left_transcript);
+        let right_record = TranscriptRecord::from_session(&right_state, &right_transcript);
+
+        let left = SessionComparisonSide::from_parts(&left_state, &left_record);
+        let right = SessionComparisonSide::from_parts(&right_state, &right_record);
+        let comparison = SessionComparison::new(left.clone(), right.clone());
+
+        assert_eq!(comparison.left_session_id, left_state.session_id);
+        assert_eq!(comparison.right_session_id, right_state.session_id);
+        assert_eq!(comparison.left, left);
+        assert_eq!(comparison.right, right);
+        assert!(!comparison.differences.same_session);
+        assert_eq!(comparison.differences.created_at_ms_delta, 50);
+        assert_eq!(comparison.differences.updated_at_ms_delta, 400);
+        assert_eq!(comparison.differences.message_count_delta, 2);
+        assert_eq!(comparison.differences.transcript_entry_count_delta, 2);
+
+        let reversed = SessionComparison::new(right.clone(), left.clone());
+        assert_eq!(reversed.differences.created_at_ms_delta, -50);
+        assert_eq!(reversed.differences.updated_at_ms_delta, -400);
+        assert_eq!(reversed.differences.message_count_delta, -2);
+        assert_eq!(reversed.differences.transcript_entry_count_delta, -2);
+
+        let self_compare = SessionComparison::new(left.clone(), left.clone());
+        assert!(self_compare.differences.same_session);
+        assert_eq!(self_compare.differences.created_at_ms_delta, 0);
+        assert_eq!(self_compare.differences.updated_at_ms_delta, 0);
+        assert_eq!(self_compare.differences.message_count_delta, 0);
+        assert_eq!(self_compare.differences.transcript_entry_count_delta, 0);
+
+        let serialized = serde_json::to_string(&comparison).expect("serialize comparison");
+        let again = serde_json::to_string(&comparison).expect("serialize comparison again");
+        assert_eq!(serialized, again, "comparison serialization should be deterministic");
+        let roundtrip: SessionComparison =
+            serde_json::from_str(&serialized).expect("deserialize comparison");
+        assert_eq!(roundtrip, comparison);
     }
 
     #[test]


### PR DESCRIPTION
Closes #34.

## Summary
- Add `session-compare <left-id> <right-id>` CLI path with `latest` accepted on either side.
- Output is a deterministic JSON bundle: `{ left_session_id, right_session_id, left, right, differences }`, where each side carries `session_id`, `created_at_ms`, `updated_at_ms`, `message_count`, and `transcript_entry_count`, and `differences` reports signed `right - left` deltas plus a `same_session` flag.
- Documentation in `README.md`, `ARCHITECTURE.md`, and `PORTING_PLAN.md` updated so the persisted-session workflow matches repo truth.

## Scope preserved
- `bootstrap`, `resume`, `sessions`, `session-show`, `transcript-show`, and `session-export` behavior is unchanged.

## Tests added
- `harness-session`: `SessionComparison` types with signed deltas (forward/reverse), `same_session` flag, and deterministic serialization round-trip.
- `harness-runtime`: `compare_sessions` for explicit ids, `latest` on either side, and self-compare.
- `harness-cli`: README-backed coverage for `session-compare <left-id> <right-id>` (two-session) and `session-compare latest latest` (self-compare) examples.

## Validation performed
- \`cargo check\`
- \`cargo test -p harness-session\`
- \`cargo test -p harness-runtime\`
- \`cargo test -p harness-cli\`
- \`cargo test\` (all crates green)
- \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- Manual CLI smoke: \`session-compare latest latest\` on a seeded `.sessions/` directory matches the README contract.

## Test plan
- [x] New `SessionComparison` type covers forward/reverse/same deltas
- [x] Runtime `compare_sessions` resolves both explicit ids and `latest`
- [x] README examples match actual CLI output (enforced by tests)
- [x] Existing persisted-session commands unchanged