### PR TITLE
feat: add CLI session-fork for persisted sessions (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The first meaningful milestone is:
 - tool and command registries
 - deterministic routing
 - runtime turn processor with structured events
-- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, session inspection, transcript inspection, session export, session comparison, session deletion, session import, and session search
+- CLI commands for summary, route, bootstrap, resume, tools, commands, session listing, session inspection, transcript inspection, session export, session comparison, session deletion, session import, session search, and session fork
 
 See:
 
@@ -748,6 +748,42 @@ cargo run -q -p harness-cli -- session-find definitely-not-present
 []
 ```
 
+### `session-fork <source-session-id> "try again"`
+
+Fork a persisted session so a new line of work can diverge from an existing turn without mutating the source. The fork creates a fresh `session_id`, carries forward the source session's messages and transcript in order, and appends the new prompt as the first divergent turn. Both persisted artifacts are written for the forked session — the session JSON at `.sessions/<forked-session-id>.json` and the sibling transcript JSON at `.sessions/<forked-session-id>.transcript.json` — while the source session JSON and transcript are left exactly as they were. The output uses a deterministic shape: `{ source_session_id, forked_session_id, appended_turn_index, session_path, transcript_path }`. `source_session_id` confirms which session the fork diverged from, `forked_session_id` is the new persisted id, and `appended_turn_index` marks where the new prompt landed in the forked transcript (equal to the source's message count).
+
+```bash
+cargo run -q -p harness-cli -- session-fork <source-session-id> "try again"
+```
+
+```json
+{
+  "source_session_id": "<source-session-id>",
+  "forked_session_id": "<forked-session-id>",
+  "appended_turn_index": 1,
+  "session_path": ".sessions/<forked-session-id>.json",
+  "transcript_path": ".sessions/<forked-session-id>.transcript.json"
+}
+```
+
+### `session-fork latest "try again"`
+
+`latest` resolves to the most recently active persisted session, mirroring how `session-show latest`, `transcript-show latest`, `session-export latest`, `session-compare latest latest`, and `session-delete latest` resolve their targets. This is the ergonomic way to branch off the session you just worked on without having to copy its id by hand.
+
+```bash
+cargo run -q -p harness-cli -- session-fork latest "try again"
+```
+
+```json
+{
+  "source_session_id": "<source-session-id>",
+  "forked_session_id": "<forked-session-id>",
+  "appended_turn_index": 1,
+  "session_path": ".sessions/<forked-session-id>.json",
+  "transcript_path": ".sessions/<forked-session-id>.transcript.json"
+}
+```
+
 ## Rust Test Coverage Baseline
 
 Current protected Rust surface:
@@ -782,6 +818,9 @@ Current protected Rust surface:
 - `harness-session` `SessionStore::find` behavior: matches persisted transcript prompt text case-insensitively, orders results using the existing newest-first session ordering, preserves `turn_index` ordering inside each result's `matches` array, and returns an empty result set for both an empty query and a query with no matches without mutating any persisted session state
 - `harness-runtime` `find_sessions` behavior: surfaces matches across bootstrap and resume-appended turns for an explicit query, scopes to sessions whose transcripts contain the query, and treats both unmatched queries and the empty query as a clean empty result set
 - README-backed CLI coverage for `session-find <query>` confirming a positive search reports the matched session id with `turn_index`-ordered `matches`, and that a query with no matches produces a deterministic empty JSON array
+- `harness-session` `SessionStore::fork` behavior: creates a fresh `session_id` rather than mutating the source, copies source messages and transcript entries forward in turn-index order, appends the new prompt as the first divergent turn, persists both the forked session JSON and its sibling transcript JSON, leaves the source session JSON and transcript exactly as they were, and reports `SessionNotFound` cleanly when the source id does not exist
+- `harness-runtime` `fork_session` behavior: resolves the `latest` selector to the most recently active persisted session, delegates to the store to write the forked session plus transcript, and fails cleanly for a missing source id without leaving partial persisted artifacts behind
+- README-backed CLI coverage for `session-fork <source-session-id> "try again"` and `session-fork latest "try again"` confirming the output identifies both the source and forked session ids, exposes the `appended_turn_index`, and reports the written session and transcript paths while the source session and transcript remain unchanged
 
 Validation commands:
 
@@ -843,3 +882,4 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] CLI session deletion for persisted sessions (`session-delete <id>` and `session-delete latest`) that removes both the session JSON and its sibling transcript JSON in one call, with deterministic JSON output identifying the deleted session id plus the removed paths, and a clean failure when the target session does not exist
 - [x] CLI session import for persisted session bundles (`session-import <bundle-path>`) that accepts the deterministic `{ exported_session_id, session, transcript }` shape emitted by `session-export`, recreates both persisted artifacts preserving the imported session id, recency/activity metadata, and transcript `turn_index` ordering, and fails cleanly without overwriting unrelated persisted sessions when the bundle is invalid or the target session id already exists locally
 - [x] CLI session search for persisted transcripts (`session-find <query>`) that case-insensitively matches transcript prompt text without mutating session state, returns a deterministic JSON array ordered using the existing newest-first session ordering, identifies each matched `session_id` with recency/activity metadata plus a `matches` array of `{ turn_index, prompt }` so results are useful from the terminal, and treats both empty queries and queries with no matches as a clean empty array instead of an error
+- [x] CLI session fork for persisted sessions (`session-fork <id> <prompt>` and `session-fork latest <prompt>`) that creates a fresh persisted session id rather than mutating the source, carries the source session messages and transcript forward in turn-index order, appends the new prompt as the first divergent turn, writes both forked persisted artifacts (`.sessions/<forked-session-id>.json` and its sibling transcript JSON), and emits a deterministic `{ source_session_id, forked_session_id, appended_turn_index, session_path, transcript_path }` shape while leaving the source session and transcript unchanged

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -26,6 +26,7 @@ enum CliCommand {
     SessionDelete { id: String },
     SessionImport { path: String },
     SessionFind { query: String },
+    SessionFork { id: String, prompt: String },
 }
 
 fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
@@ -95,6 +96,12 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
                 .expect("search persisted sessions");
             serde_json::to_string_pretty(&results).expect("serialize session find results")
         }
+        CliCommand::SessionFork { id, prompt } => {
+            let fork = engine
+                .fork_session(&id, Prompt::new(prompt))
+                .expect("fork persisted session");
+            serde_json::to_string_pretty(&fork).expect("serialize session fork")
+        }
     }
 }
 
@@ -111,8 +118,8 @@ mod tests {
     use harness_commands::CommandRegistry;
     use harness_runtime::RuntimeEngine;
     use harness_session::{
-        SessionComparison, SessionDeletion, SessionExport, SessionFindResult, SessionImport,
-        SessionState, SessionStore, TranscriptRecord,
+        SessionComparison, SessionDeletion, SessionExport, SessionFindResult, SessionFork,
+        SessionImport, SessionState, SessionStore, TranscriptRecord,
     };
     use harness_tools::{PermissionPolicy, ToolRegistry};
     use std::fs;
@@ -242,6 +249,19 @@ mod tests {
 
     fn normalize_session_output(output: &str, session_id: &str) -> String {
         normalize_timestamps(&output.replace(session_id, "<session-id>"))
+    }
+
+    fn normalize_fork_output(
+        output: &str,
+        source_session_id: &str,
+        forked_session_id: &str,
+        root: &Path,
+    ) -> String {
+        let replaced = output
+            .replace(root.to_string_lossy().as_ref(), ".sessions")
+            .replace(forked_session_id, "<forked-session-id>")
+            .replace(source_session_id, "<source-session-id>");
+        normalize_timestamps(&replaced)
     }
 
     #[test]
@@ -990,6 +1010,137 @@ mod tests {
         assert_eq!(
             find_output,
             readme_output_block("session-find <unmatched-query>", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_fork_matches_readme_example_and_creates_fresh_session_id() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let source_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let fork_output = render_command(
+            &engine,
+            CliCommand::SessionFork {
+                id: source_id.clone(),
+                prompt: "try again".to_string(),
+            },
+        );
+
+        let fork: SessionFork =
+            serde_json::from_str(&fork_output).expect("parse session-fork output");
+        assert_eq!(
+            fork.source_session_id.to_string(),
+            source_id,
+            "source_session_id must match the targeted source"
+        );
+        assert_ne!(
+            fork.forked_session_id.to_string(),
+            source_id,
+            "forked session id must differ from source"
+        );
+        assert_eq!(fork.appended_turn_index.0, 1);
+        assert_eq!(
+            fork.session_path,
+            root.join(format!("{}.json", fork.forked_session_id))
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            fork.transcript_path,
+            root.join(format!("{}.transcript.json", fork.forked_session_id))
+                .display()
+                .to_string()
+        );
+        assert!(Path::new(&fork.session_path).exists());
+        assert!(Path::new(&fork.transcript_path).exists());
+
+        let forked: SessionState = engine
+            .load_session(&fork.forked_session_id.to_string())
+            .expect("reload forked session");
+        let forked_messages: Vec<String> = forked
+            .messages
+            .iter()
+            .map(|prompt| prompt.0.clone())
+            .collect();
+        assert_eq!(
+            forked_messages,
+            vec!["review bash".to_string(), "try again".to_string()],
+            "forked session must carry source messages then append the new prompt"
+        );
+
+        let source: SessionState = engine
+            .load_session(&source_id)
+            .expect("source session must still load");
+        let source_messages: Vec<String> = source
+            .messages
+            .iter()
+            .map(|prompt| prompt.0.clone())
+            .collect();
+        assert_eq!(
+            source_messages,
+            vec!["review bash".to_string()],
+            "source session must not be mutated by fork"
+        );
+
+        let forked_id = fork.forked_session_id.to_string();
+        assert_eq!(
+            normalize_fork_output(&fork_output, &source_id, &forked_id, &root),
+            readme_output_block("session-fork <source-session-id> \"try again\"", "json")
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp cli test directory");
+    }
+
+    #[test]
+    fn session_fork_latest_matches_readme_example_and_targets_most_recent() {
+        let root = temp_session_root();
+        let engine = temp_engine(&root);
+
+        let bootstrap_output = render_command(
+            &engine,
+            CliCommand::Bootstrap {
+                prompt: "review bash".to_string(),
+            },
+        );
+        let bootstrap_json: serde_json::Value =
+            serde_json::from_str(&bootstrap_output).expect("parse bootstrap report");
+        let source_id = bootstrap_json["session"]["session_id"]
+            .as_str()
+            .expect("session id in bootstrap output")
+            .to_string();
+
+        let latest_output = render_command(
+            &engine,
+            CliCommand::SessionFork {
+                id: "latest".to_string(),
+                prompt: "try again".to_string(),
+            },
+        );
+
+        let fork: SessionFork =
+            serde_json::from_str(&latest_output).expect("parse session-fork latest output");
+        assert_eq!(fork.source_session_id.to_string(), source_id);
+        assert_ne!(fork.forked_session_id.to_string(), source_id);
+
+        let forked_id = fork.forked_session_id.to_string();
+        assert_eq!(
+            normalize_fork_output(&latest_output, &source_id, &forked_id, &root),
+            readme_output_block("session-fork latest \"try again\"", "json")
         );
 
         fs::remove_dir_all(&root).expect("remove temp cli test directory");

--- a/crates/harness-runtime/src/lib.rs
+++ b/crates/harness-runtime/src/lib.rs
@@ -4,7 +4,8 @@ use harness_core::{
 };
 use harness_session::{
     SessionComparison, SessionComparisonSide, SessionDeletion, SessionExport, SessionFindResult,
-    SessionImport, SessionListing, SessionState, SessionStore, TranscriptRecord, TranscriptStore,
+    SessionFork, SessionImport, SessionListing, SessionState, SessionStore, TranscriptRecord,
+    TranscriptStore,
 };
 use std::fs;
 use std::path::Path;
@@ -428,6 +429,13 @@ impl RuntimeEngine {
         })?;
         self.store
             .import_bundle(&bundle)
+            .map_err(|err| err.to_string())
+    }
+
+    pub fn fork_session(&self, target: &str, prompt: Prompt) -> Result<SessionFork, String> {
+        let source = self.load_session(target)?;
+        self.store
+            .fork(&source.session_id.to_string(), prompt)
             .map_err(|err| err.to_string())
     }
 
@@ -1066,6 +1074,154 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn fork_session_creates_fresh_session_id_preserves_source_and_supports_latest() {
+        use harness_core::{Prompt, TurnIndex};
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let bootstrap = engine
+            .bootstrap(Prompt::new("review bash"))
+            .expect("bootstrap session");
+        let source_id = bootstrap.session.session_id.to_string();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let _ = engine
+            .resume(&source_id, Prompt::new("summary please"))
+            .expect("resume source session");
+
+        let fork = engine
+            .fork_session(&source_id, Prompt::new("try again"))
+            .expect("fork source session by id");
+
+        assert_eq!(fork.source_session_id.to_string(), source_id);
+        assert_ne!(
+            fork.forked_session_id.to_string(),
+            source_id,
+            "forked session id must differ from source"
+        );
+        assert_eq!(fork.appended_turn_index, TurnIndex(2));
+        assert!(
+            std::path::Path::new(&fork.session_path).exists(),
+            "forked session file must be written"
+        );
+        assert!(
+            std::path::Path::new(&fork.transcript_path).exists(),
+            "forked transcript file must be written"
+        );
+
+        let forked_session = engine
+            .load_session(&fork.forked_session_id.to_string())
+            .expect("load forked session");
+        let forked_messages: Vec<String> = forked_session
+            .messages
+            .iter()
+            .map(|prompt| prompt.0.clone())
+            .collect();
+        assert_eq!(
+            forked_messages,
+            vec![
+                "review bash".to_string(),
+                "summary please".to_string(),
+                "try again".to_string(),
+            ]
+        );
+
+        let forked_transcript = engine
+            .load_transcript(&fork.forked_session_id.to_string())
+            .expect("load forked transcript");
+        let ordered: Vec<(usize, String)> = forked_transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+                (2, "try again".to_string()),
+            ]
+        );
+
+        let source_session = engine
+            .load_session(&source_id)
+            .expect("source session must still load");
+        let source_messages: Vec<String> = source_session
+            .messages
+            .iter()
+            .map(|prompt| prompt.0.clone())
+            .collect();
+        assert_eq!(
+            source_messages,
+            vec!["review bash".to_string(), "summary please".to_string()],
+            "source session must not be mutated by the fork"
+        );
+        let source_transcript = engine
+            .load_transcript(&source_id)
+            .expect("source transcript must still load");
+        let source_ordered: Vec<(usize, String)> = source_transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            source_ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+            ],
+            "source transcript must not be mutated by the fork"
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let latest_fork = engine
+            .fork_session("latest", Prompt::new("via latest"))
+            .expect("fork via latest selector");
+        assert_eq!(
+            latest_fork.source_session_id.to_string(),
+            fork.forked_session_id.to_string(),
+            "`latest` must resolve to the most recently active persisted session (the prior fork)"
+        );
+        assert_ne!(
+            latest_fork.forked_session_id, fork.forked_session_id,
+            "latest-fork must produce a fresh session id"
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp runtime test directory");
+    }
+
+    #[test]
+    fn fork_session_reports_missing_source_cleanly() {
+        use harness_core::{Prompt, SessionId};
+
+        let root = temp_session_root();
+        let engine = RuntimeEngine {
+            commands: CommandRegistry::seeded(),
+            tools: ToolRegistry::seeded(),
+            permissions: PermissionPolicy::with_denied_prefixes(["bash"]),
+            store: SessionStore::new(&root),
+        };
+
+        let missing = SessionId::new().to_string();
+        let result = engine.fork_session(&missing, Prompt::new("will not land"));
+        assert!(result.is_err(), "missing source id must fail");
+        assert!(
+            engine
+                .list_sessions()
+                .expect("list sessions after failed fork")
+                .is_empty(),
+            "no persisted sessions should exist after a failed fork"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/crates/harness-session/src/lib.rs
+++ b/crates/harness-session/src/lib.rs
@@ -205,6 +205,15 @@ pub struct SessionImport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionFork {
+    pub source_session_id: SessionId,
+    pub forked_session_id: SessionId,
+    pub appended_turn_index: TurnIndex,
+    pub session_path: String,
+    pub transcript_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionListing {
     pub session_id: SessionId,
     pub created_at_ms: u64,
@@ -369,6 +378,54 @@ impl SessionStore {
             imported_session_id: bundle.session.session_id.clone(),
             session_path: saved_session_path.display().to_string(),
             transcript_path: saved_transcript_path.display().to_string(),
+        })
+    }
+
+    pub fn fork(
+        &self,
+        source_session_id: &str,
+        prompt: Prompt,
+    ) -> Result<SessionFork, RuntimeError> {
+        let source_session = self.load(source_session_id)?;
+        let source_transcript = self.load_transcript(source_session_id)?;
+
+        let forked_session_id = SessionId::new();
+        let now = current_timestamp_ms();
+        let appended_turn_index = TurnIndex(source_session.messages.len());
+
+        let mut forked_messages = source_session.messages.clone();
+        forked_messages.push(prompt.clone());
+
+        let forked_session = SessionState {
+            session_id: forked_session_id.clone(),
+            created_at_ms: now,
+            updated_at_ms: now,
+            messages: forked_messages,
+            usage: source_session.usage.add_turn(prompt.as_str(), "turn forked"),
+        };
+
+        let mut forked_entries = source_transcript.entries.clone();
+        forked_entries.push(TranscriptEntry {
+            turn_index: appended_turn_index,
+            prompt,
+        });
+
+        let forked_transcript = TranscriptRecord {
+            session_id: forked_session_id.clone(),
+            created_at_ms: now,
+            updated_at_ms: now,
+            entries: forked_entries,
+        };
+
+        let session_path = self.save(&forked_session)?;
+        let transcript_path = self.save_transcript(&forked_transcript)?;
+
+        Ok(SessionFork {
+            source_session_id: source_session.session_id,
+            forked_session_id,
+            appended_turn_index,
+            session_path: session_path.display().to_string(),
+            transcript_path: transcript_path.display().to_string(),
         })
     }
 
@@ -1260,6 +1317,124 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn fork_creates_new_session_id_carries_transcript_and_appends_divergent_turn() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+
+        let source = SessionState {
+            session_id: SessionId::new(),
+            created_at_ms: 1_700_000_000_001,
+            updated_at_ms: 1_700_000_000_050,
+            messages: vec![Prompt::new("review bash"), Prompt::new("summary please")],
+            usage: harness_core::UsageSummary {
+                input_tokens: 4,
+                output_tokens: 4,
+            },
+        };
+        let mut source_transcript = TranscriptStore::default();
+        source_transcript.append(Prompt::new("review bash"));
+        source_transcript.append(Prompt::new("summary please"));
+        let source_record = TranscriptRecord::from_session(&source, &source_transcript);
+
+        store.save(&source).expect("save source session");
+        store
+            .save_transcript(&source_record)
+            .expect("save source transcript");
+
+        let fork = store
+            .fork(&source.session_id.to_string(), Prompt::new("try again"))
+            .expect("fork source session");
+
+        assert_eq!(fork.source_session_id, source.session_id);
+        assert_ne!(
+            fork.forked_session_id, source.session_id,
+            "forked session must use a fresh session id"
+        );
+        assert_eq!(fork.appended_turn_index, TurnIndex(2));
+        assert_eq!(
+            fork.session_path,
+            root.join(format!("{}.json", fork.forked_session_id))
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            fork.transcript_path,
+            root.join(format!("{}.transcript.json", fork.forked_session_id))
+                .display()
+                .to_string()
+        );
+
+        let forked_session = store
+            .load(&fork.forked_session_id.to_string())
+            .expect("load forked session");
+        assert_eq!(
+            forked_session
+                .messages
+                .iter()
+                .map(|prompt| prompt.0.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                "review bash".to_string(),
+                "summary please".to_string(),
+                "try again".to_string(),
+            ],
+            "forked session must carry source messages then append the new prompt"
+        );
+
+        let forked_transcript = store
+            .load_transcript(&fork.forked_session_id.to_string())
+            .expect("load forked transcript");
+        let ordered: Vec<(usize, String)> = forked_transcript
+            .entries
+            .iter()
+            .map(|entry| (entry.turn_index.0, entry.prompt.0.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (0, "review bash".to_string()),
+                (1, "summary please".to_string()),
+                (2, "try again".to_string()),
+            ],
+            "forked transcript must preserve turn ordering and append the new prompt"
+        );
+        assert_eq!(forked_transcript.session_id, fork.forked_session_id);
+
+        let reloaded_source = store
+            .load(&source.session_id.to_string())
+            .expect("source session must survive");
+        assert_eq!(reloaded_source, source, "source session must not be mutated");
+        let reloaded_source_transcript = store
+            .load_transcript(&source.session_id.to_string())
+            .expect("source transcript must survive");
+        assert_eq!(
+            reloaded_source_transcript, source_record,
+            "source transcript must not be mutated"
+        );
+
+        fs::remove_dir_all(&root).expect("remove temp session test directory");
+    }
+
+    #[test]
+    fn fork_errors_cleanly_when_source_session_is_missing() {
+        let root = temp_session_root();
+        let store = SessionStore::new(&root);
+
+        let missing = SessionId::new().to_string();
+        match store.fork(&missing, Prompt::new("forked prompt")) {
+            Err(RuntimeError::SessionNotFound(reported)) => assert_eq!(reported, missing),
+            other => panic!("expected SessionNotFound for missing source id, got {other:?}"),
+        }
+
+        assert!(
+            !root.exists() || fs::read_dir(&root).map(|mut iter| iter.next().is_none()).unwrap_or(true),
+            "no persisted artifacts should be written when fork source is missing"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds user-facing `session-fork <id> <prompt>` and `session-fork latest <prompt>` CLI subcommands for branching a persisted session without mutating the source. Closes #42.

- **Fork semantics**: mint a fresh `session_id`, carry the source session's messages and transcript forward in `turn_index` order, append the new prompt as the first divergent turn, and write both forked persisted artifacts (`.sessions/<forked-session-id>.json` + sibling transcript JSON). The source session JSON and transcript stay byte-for-byte unchanged.
- **Deterministic output shape**: `{ source_session_id, forked_session_id, appended_turn_index, session_path, transcript_path }` — identifies the divergence point, the new persisted id, the stable fork-point (`appended_turn_index` equals the source's message count), and the written paths in the same style as `session-import`.
- **`latest` selector** resolves to the most recently active persisted session, mirroring every other `session-*` command.

## Layer-by-layer

- `harness-session`: new `SessionFork` struct and `SessionStore::fork`, with tests for fresh-id creation, carried-forward messages/transcript ordering, source-preservation, and clean `SessionNotFound` on missing source.
- `harness-runtime`: new `RuntimeEngine::fork_session` that resolves `latest` and delegates to the store; tests cover id + `latest` targeting, source-preservation, and clean failure for a missing source.
- `harness-cli`: new `SessionFork` subcommand wired through `render_command`; README-backed regression tests for both the explicit-id and `latest` forms using a dedicated `<source-session-id>` / `<forked-session-id>` normalizer.
- `README.md`: two protected example blocks, coverage-baseline bullets, and a new roadmap entry.

## Test plan

- [x] `cargo test -p harness-session` — 19 tests (2 new) pass
- [x] `cargo test -p harness-runtime` — 14 tests (2 new) pass
- [x] `cargo test -p harness-cli` — 22 tests (2 new) pass
- [x] `cargo test` — full workspace green (64 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean