### PR TITLE
docs(cli): align resume selector docs/help with runtime support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,7 +225,7 @@ User-facing CLI:
 - `summary`
 - `route <prompt>`
 - `bootstrap <prompt>`
-- `resume <id> <prompt>` and `resume latest <prompt>` (append a new turn to an existing persisted session; output confirms the targeted session id and appended turn index)
+- `resume <selector> <prompt>` (accepts raw `session_id`, `latest`, or `label:<name>` — routed through the shared selector-resolution path; appends a new turn to the resolved persisted session, refreshes `updated_at_ms` so subsequent `latest` lookups point at the most recently active session, and rewrites the sibling transcript so `turn_index` ordering is extended in place; machine-readable JSON output identifies the resolved persisted `session_id` via `resumed_session_id` rather than the typed selector string and exposes the appended turn index; selector failures stay deterministic — unknown id/label → `SessionNotFound`, duplicate labels → `AmbiguousLabel`, empty `label:` → `MalformedSelector`)
 - `tools list`
 - `commands list`
 - `sessions` with optional `--limit <n>` (inspect-only listing that preserves the existing newest-first ordering — `updated_at_ms` → `created_at_ms` → `session_id` → `persisted_path`; omitting `--limit` returns every persisted session unchanged; `--limit <n>` returns at most the newest `n` rows from that same ordering, `--limit 0` returns an empty array cleanly, a `--limit` larger than the store returns every available session cleanly, and the per-row JSON shape stays the same — the limited form is a slice of the existing array, not a new wrapper object; does not mutate any persisted session, transcript entry, label, pinned flag, id, path, or ordering metadata)

--- a/PORTING_PLAN.md
+++ b/PORTING_PLAN.md
@@ -60,7 +60,7 @@ Build a Rust-native Claude Code-style CLI/runtime that Hamza can use as a primar
 - [x] `summary`
 - [x] `route <prompt>`
 - [x] `bootstrap <prompt>`
-- [x] `resume <id> <prompt>` (and `resume latest <prompt>`) — append a new turn to an existing persisted session; output confirms the targeted session id, the appended turn index, and the refreshed `updated_at_ms` activity metadata
+- [x] `resume <selector> <prompt>` — append a new turn to an existing persisted session; `<selector>` accepts raw `session_id`, `latest`, or `label:<name>` routed through the shared selector-resolution path; the resumed turn is appended to the same persisted session file, `updated_at_ms` is refreshed, and the sibling transcript is rewritten so `turn_index` ordering is extended in place; output is machine-readable JSON that identifies the resolved persisted `session_id` via `resumed_session_id` rather than the typed selector string and exposes the appended turn index; selector failure semantics stay deterministic (unknown id/label → `SessionNotFound`, duplicate labels → `AmbiguousLabel`, empty `label:` → `MalformedSelector`)
 - [x] `tools`
 - [x] `commands`
 - [x] `session-show <selector>` — inspect the persisted state of a single session; `<selector>` accepts raw `session_id`, `latest`, or `label:<name>` routed through the shared selector-resolution path; output is machine-readable JSON that surfaces the actual resolved `session_id` rather than the typed selector string; selector failure semantics stay deterministic (unknown id/label → `SessionNotFound`, duplicate labels → `AmbiguousLabel`, empty `label:` → `MalformedSelector`)

--- a/README.md
+++ b/README.md
@@ -293,9 +293,9 @@ cargo run -q -p harness-cli -- bootstrap "review bash"
 }
 ```
 
-### `resume <id> "review summary"`
+### `resume <selector> "review summary"`
 
-Append a new turn to an existing persisted session. Pass either an explicit session id or the literal `latest` target. The resumed turn is appended to the same session file rather than starting a new session, and `updated_at_ms` is refreshed so subsequent `latest` lookups point at the most recently active session.
+Append a new turn to an existing persisted session. `<selector>` accepts raw `session_id`, `latest`, or `label:<name>` — all three forms are routed through the shared selector-resolution path so `resume` targets the same persisted session regardless of which form was typed. The resumed turn is appended to the same session file rather than starting a new session, and `updated_at_ms` is refreshed so subsequent `latest` lookups point at the most recently active session. Machine-readable JSON output continues to identify the actual resolved `session_id` via `resumed_session_id` rather than echoing the selector string, so downstream tooling can rely on the resolved id even when the user typed `label:<name>` or `latest`. Selector failures are deterministic: unknown id/label surfaces as `SessionNotFound`, duplicate labels as `AmbiguousLabel`, and an empty `label:` as `MalformedSelector`.
 
 ```bash
 cargo run -q -p harness-cli -- resume <session-id> "review summary"
@@ -402,10 +402,11 @@ cargo run -q -p harness-cli -- resume <session-id> "review summary"
 }
 ```
 
-`latest` is supported as the resume target too:
+`latest` and `label:<name>` are supported as resume targets too:
 
 ```bash
 cargo run -q -p harness-cli -- resume latest "review summary"
+cargo run -q -p harness-cli -- resume label:runtime-review "review summary"
 ```
 
 ### `sessions`
@@ -1644,7 +1645,7 @@ Current protected Rust surface:
 - README-backed CLI output regression coverage for `summary`, `route <prompt>`, `tools`, `commands`, and `sessions`
 - README-backed persisted-session example coverage for `bootstrap <prompt>`, `session-show <selector>` (raw id, `latest`, and `label:<name>`), with generated session identifiers normalized to `<session-id>` and generated recency metadata normalized to `<created-at-ms>` / `<updated-at-ms>` in test assertions
 - `harness-runtime` session resume behavior: an appended turn targets the original session id, bumps `updated_at_ms`, and emits a `SessionResumed` event; `resume latest` targets the most recently active session
-- README-backed CLI coverage for `resume <id> "review summary"` confirming the resumed turn is appended to the existing persisted session and the output exposes the targeted session id plus the appended turn index
+- README-backed CLI coverage for `resume <selector> "review summary"` (raw id, `latest`, and `label:<name>`) confirming the resumed turn is appended to the existing persisted session and the output exposes the resolved `resumed_session_id` plus the appended turn index
 - `harness-session` transcript persistence: save/load round-trip preserves `turn_index` ordering, transcript files are excluded from session listings, and `latest_transcript` follows the most recently updated session
 - `harness-runtime` transcript persistence: `bootstrap` writes a transcript file alongside the session, emits a `TranscriptPersisted` event, and `resume` rewrites the transcript so `turn_index` ordering is extended in place
 - README-backed CLI coverage for `transcript-show <selector>` (raw id, `latest`, and `label:<name>`) confirming the output restates the owning `session_id` and preserves turn ordering, plus selector failure coverage for unknown / ambiguous / malformed label selectors on both `session-show` and `transcript-show`
@@ -1779,7 +1780,7 @@ This repo is a clean-room implementation effort informed by architectural study.
 - [x] CLI usage examples and validation flow
 - [x] cleanup of obsolete Python-first scaffolding
 - [x] move retained architecture-study snapshots under `archive/reference_data/`
-- [x] CLI session resume for persisted sessions (explicit id and `latest`)
+- [x] CLI session resume for persisted sessions (`resume <selector> <prompt>` — raw id, `latest`, and `label:<name>`) routed through the shared selector-resolution path; the resumed turn is appended to the existing persisted session, `updated_at_ms` is refreshed, and machine-readable JSON output continues to identify the actual resolved `session_id` via `resumed_session_id` rather than the typed selector string; selector failures stay deterministic (unknown id/label → `SessionNotFound`, duplicate labels → `AmbiguousLabel`, empty `label:` → `MalformedSelector`)
 - [x] Persisted transcript files per session and CLI transcript inspection (`transcript-show <selector>` — raw id, `latest`, and `label:<name>`)
 - [x] CLI session export for persisted session bundles (`session-export <selector>` — raw id, `latest`, and `label:<name>`) in a deterministic JSON shape packaging session state plus transcript, with `exported_session_id` surfacing the actual resolved `session_id` rather than the typed selector string and selector failures routed through the shared `SessionNotFound` / `AmbiguousLabel` / `MalformedSelector` diagnostics
 - [x] CLI session comparison for persisted sessions (`session-compare <left-selector> <right-selector>` — each side independently accepts raw `session_id`, `latest`, or `label:<name>` routed through the shared selector-resolution path) in a deterministic JSON shape that identifies both compared session ids as the actual resolved `session_id` values (never the typed selector strings) and reports signed deltas for recency metadata and transcript/turn counts, with selector failure semantics routed through the shared `SessionNotFound` / `AmbiguousLabel` / `MalformedSelector` diagnostics independently on each side

--- a/crates/harness-cli/src/main.rs
+++ b/crates/harness-cli/src/main.rs
@@ -23,8 +23,11 @@ enum CliCommand {
     Bootstrap {
         prompt: String,
     },
+    /// Resume a persisted session by selector (raw id, latest, or label:<name>)
+    #[command(about = "Append a new turn to a persisted session using a selector (id, latest, or label:<name>) <PROMPT>")]
     Resume {
-        id: String,
+        #[arg(value_name = "SELECTOR")]
+        selector: String,
         prompt: String,
     },
     Tools,
@@ -201,10 +204,10 @@ fn render_command(engine: &RuntimeEngine, command: CliCommand) -> String {
                 .expect("bootstrap runtime turn");
             serde_json::to_string_pretty(&report).expect("serialize bootstrap report")
         }
-        CliCommand::Resume { id, prompt } => {
+        CliCommand::Resume { selector, prompt } => {
             let report = engine
-                .resume(&id, Prompt::new(prompt))
-                .expect("resume persisted session");
+                .resume(&selector, Prompt::new(prompt))
+                .expect("resume persisted session by selector");
             serde_json::to_string_pretty(&report).expect("serialize resume report")
         }
         CliCommand::Tools => {
@@ -915,6 +918,43 @@ mod tests {
     }
 
     #[test]
+    fn resume_help_mentions_selector_usage() {
+        use clap::{CommandFactory, FromArgMatches};
+
+        let command = Cli::command();
+        let matches = command
+            .clone()
+            .try_get_matches_from(["harness", "resume", "--help"])
+            .expect_err("--help should short-circuit with a displayable clap error");
+        let rendered = matches.to_string();
+        assert!(
+            rendered.contains("resume <SELECTOR> <PROMPT>"),
+            "help output must advertise selector usage: {rendered}"
+        );
+        assert!(
+            rendered.contains("selector (id, latest, or label:<name>)"),
+            "help output must describe supported selector forms: {rendered}"
+        );
+
+        let parsed = Cli::from_arg_matches(
+            &command
+                .try_get_matches_from([
+                    "harness",
+                    "resume",
+                    "label:runtime-review",
+                    "review summary",
+                ])
+                .expect("selector-form resume invocation should parse"),
+        )
+        .expect("selector-form resume invocation should materialize a CLI command");
+        assert!(matches!(
+            parsed.command,
+            CliCommand::Resume { selector, prompt }
+                if selector == "label:runtime-review" && prompt == "review summary"
+        ));
+    }
+
+    #[test]
     fn session_unlabel_help_mentions_selector_usage() {
         use clap::{CommandFactory, FromArgMatches};
 
@@ -1044,7 +1084,7 @@ mod tests {
         let resume_output = render_command(
             &engine,
             CliCommand::Resume {
-                id: session_id.clone(),
+                selector: session_id.clone(),
                 prompt: "review summary".to_string(),
             },
         );
@@ -1064,7 +1104,7 @@ mod tests {
 
         assert_eq!(
             normalize_bootstrap_example(&resume_output, &session_id, &root),
-            readme_output_block("resume <id> \"review summary\"", "json")
+            readme_output_block("resume <selector> \"review summary\"", "json")
         );
 
         let reloaded_output = render_command(
@@ -4466,7 +4506,7 @@ mod tests {
             render_command(
                 engine,
                 CliCommand::Resume {
-                    id: id.to_string(),
+                    selector: id.to_string(),
                     prompt: (*prompt).to_string(),
                 },
             );


### PR DESCRIPTION
## Summary
- Renames the `resume` CLI surface from id-style (`resume <id> <prompt>`) to selector-style (`resume <selector> <prompt>`) so help, README, ARCHITECTURE.md, and PORTING_PLAN.md honestly describe the already-existing runtime selector support (raw `session_id`, `latest`, `label:<name>`).
- Adds a focused `resume_help_mentions_selector_usage` clap help test and updates the README-backed heading marker (`resume <selector> "review summary"`) so `readme_output_block` lookups stay coupled.
- No runtime behavior changes: `resume` still delegates to `RuntimeEngine::resume` → `load_session` → `resolve_selector`; JSON output shape is preserved and `resumed_session_id` continues to surface the actual resolved persisted session id, never the typed selector string. Selector failure semantics (`SessionNotFound` / `AmbiguousLabel` / `MalformedSelector`) and resume semantics (append to same persisted session, refresh `updated_at_ms`) are unchanged.

Closes #128.

## Test plan
- [x] `cargo test -p harness-cli resume` — 2 passed (including new `resume_help_mentions_selector_usage`)
- [x] `cargo test -p harness-cli` — 343 passed, 0 failed